### PR TITLE
Pooja | Bugfix | Fix for primary diagnosis not seen in OT calendar view

### DIFF
--- a/ui/app/ot/directives/otCalendarSurgicalBlock.js
+++ b/ui/app/ot/directives/otCalendarSurgicalBlock.js
@@ -96,6 +96,7 @@ angular.module('bahmni.ot')
                         getCalendarEndDateTime($scope.viewDate) < surgicalAppointment.derivedAttributes.expectedEndDatetime
                             ? getCalendarEndDateTime($scope.viewDate) : surgicalAppointment.derivedAttributes.expectedEndDatetime
                     );
+                    surgicalAppointment.primaryDiagnosis = new Bahmni.OT.SurgicalBlockMapper().mapPrimaryDiagnoses(surgicalAppointment.patientObservations);
                     nextAppointmentStartDatetime = surgicalAppointment.derivedAttributes.expectedEndDatetime;
                     return surgicalAppointment;
                 });


### PR DESCRIPTION
Reverting a code change which caused Primary Diagnosis to not be displayed in OT Calendar view 