### PR TITLE
Vivek: HIVE-108160: Fix: Allergy display control not rendering in Medication tab

### DIFF
--- a/ui/app/common/displaycontrols/dashboard/models/dashboardSection.js
+++ b/ui/app/common/displaycontrols/dashboard/models/dashboardSection.js
@@ -22,13 +22,13 @@
         "conditionsList"
     ];
     var reactDisplayControls = [
-        "allergies",
+        "Allergies",
         "formsV2React",
         "ordersV2"
     ];
 
     var getViewUrl = function (section) {
-        if (reactDisplayControls.includes(section.type)) {
+        if (reactDisplayControls.includes(section.translationKey) || reactDisplayControls.includes(section.type)) {
             return DISPLAY_CONTROL_REACT_URL;
         }
         if (section.isObservation) {

--- a/ui/app/common/displaycontrols/dashboard/views/sections/nextUISection.html
+++ b/ui/app/common/displaycontrols/dashboard/views/sections/nextUISection.html
@@ -1,3 +1,3 @@
-<mfe-next-ui-patient-alergies-control ng-if="::(section.type === 'allergies')" host-data="allergyData" app-service="appService"></mfe-next-ui-patient-alergies-control>
+<mfe-next-ui-patient-alergies-control ng-if="::(section.translationKey === 'Allergies')" host-data="allergyData" app-service="appService"></mfe-next-ui-patient-alergies-control>
 <mfe-next-ui-form-display-control ng-if="::(section.type === 'formsV2React')" host-data="getSectionFormData(section)" host-api="formApi"></mfe-next-ui-form-display-control>
 <mfe-next-ui-orders-display-control ng-if="::(section.type === 'ordersV2')" host-data="ordersData"  host-api="ordersApi"></mfe-next-ui-orders-display-control>


### PR DESCRIPTION
Fix: Allergy display control not rendering in Medication tab

  Use translationKey-based detection for allergy display control instead of type,
  since CURE config defines allergy section with type allergies but relies on
  translationKey Allergies for routing to the React micro-frontend component.