### PR TITLE
Vivek: HIVE-108160: Cherry-pick - Support configurable hiding of dosage rules in medication tab

### DIFF
--- a/ui/app/clinical/consultation/services/treatmentConfig.js
+++ b/ui/app/clinical/consultation/services/treatmentConfig.js
@@ -122,6 +122,11 @@ angular.module('bahmni.clinical').factory('treatmentConfig',
                     tabConfig.durationUnits = tabConfig.inputOptionsConfig.durationUnitsFactors || defaultDurationUnitsFactors;
 
                     tabConfig.orderSet = tabConfig.orderSet || {};
+                    if (tabConfig.orderSet && tabConfig.orderSet.hideDefaultRuleList) {
+                        medicationTabConfig.dosingRules = medicationTabConfig.dosingRules.filter(function (item) {
+                            return tabConfig.orderSet.hideDefaultRuleList.indexOf(item) === -1;
+                        });
+                    }
                     var showDoseFractions = tabConfig.inputOptionsConfig.showDoseFractions;
                     tabConfig.inputOptionsConfig.showDoseFractions = showDoseFractions ? showDoseFractions : false;
                     tabConfig.drugOrderHistoryConfig = tabConfig.drugOrderHistoryConfig || {};


### PR DESCRIPTION
## Summary
  - Cherry-picks commit `6bb5a8fe8` from `Bahmni-IPD-master` into `CURE-Product-Master`
  - Adds support for `hideDefaultRuleList` config in `medication.json` to filter out unwanted dosage rules from the Order Drug
  dropdown
  - Without this, the `hideDefaultRuleList` config key in `medication.json` was silently ignored, causing all dosage rules (`mg/kg`,
   `mg/m2`, `customrule`) to appear in the dropdown

  ## Root Cause
  `treatmentConfig.js` was not reading `hideDefaultRuleList` from `medication.json`, so the existing config:
  ```json
  "hideDefaultRuleList": ["mg/m2", "customrule"]
  had no effect — all rules returned by the backend rules engine were shown.