### PR TITLE
HIVE-108160: Vivek: fix: restore unsaved consultation data alert for observation forms

### DIFF
--- a/ui/app/common/concept-set/directives/conceptSet.js
+++ b/ui/app/common/concept-set/directives/conceptSet.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.common.conceptSet')
-    .directive('conceptSet', ['contextChangeHandler', 'appService', 'observationsService', 'messagingService', 'conceptSetService', 'conceptSetUiConfigService', 'spinner',
-        function (contextChangeHandler, appService, observationsService, messagingService, conceptSetService, conceptSetUiConfigService, spinner) {
+    .directive('conceptSet', ['contextChangeHandler', 'appService', 'observationsService', 'messagingService', 'conceptSetService', 'conceptSetUiConfigService', 'spinner', '$state',
+        function (contextChangeHandler, appService, observationsService, messagingService, conceptSetService, conceptSetUiConfigService, spinner, $state) {
             var controller = function ($scope) {
                 var conceptSetName = $scope.conceptSetName;
                 var ObservationUtil = Bahmni.Common.Obs.ObservationUtil;
@@ -411,6 +411,18 @@ angular.module('bahmni.common.conceptSet')
                     deregisterObservationUpdated();
                     deregisterAddMore();
                     cleanUpListenerShowPrevious();
+                });
+
+                $scope.$on('$stateChangeStart', function () {
+                    if ($scope.obsForm && $scope.obsForm.$dirty) {
+                        $state.dirtyConsultationForm = true;
+                    }
+                });
+
+                $scope.$on("event:changes-saved", function () {
+                    if ($scope.obsForm) {
+                        $scope.obsForm.$dirty = false;
+                    }
                 });
             };
 

--- a/ui/app/common/concept-set/directives/formControls.js
+++ b/ui/app/common/concept-set/directives/formControls.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.common.conceptSet')
-    .directive('formControls', ['formService', 'spinner', '$timeout', '$translate',
-        function (formService, spinner, $timeout, $translate) {
+    .directive('formControls', ['formService', 'spinner', '$timeout', '$translate', '$state', 'messagingService', 'exitAlertService',
+        function (formService, spinner, $timeout, $translate, $state, messagingService, exitAlertService) {
             var loadedFormDetails = {};
             var loadedFormTranslations = {};
             var unMountReactContainer = function (formUuid) {
@@ -77,6 +77,71 @@ angular.module('bahmni.common.conceptSet')
                             }
                         }
                     }
+                });
+                function checkGroupMembers (formObservation, consultationObservation) {
+                    var isGroupMemberChanged = [];
+                    if (formObservation.groupMembers && formObservation.groupMembers.length > 0 && consultationObservation.groupMembers && consultationObservation.groupMembers.length > 0) {
+                        for (var formGroupIndex = 0; formGroupIndex < formObservation.groupMembers.length; formGroupIndex++) {
+                            var formGroupMember = formObservation.groupMembers[formGroupIndex];
+                            for (var consultationGroupIndex = 0; consultationGroupIndex < consultationObservation.groupMembers.length; consultationGroupIndex++) {
+                                var consultationGroupMember = consultationObservation.groupMembers[consultationGroupIndex];
+                                (formGroupMember.value && formGroupMember.value.uuid && consultationGroupMember.value && consultationGroupMember.value.uuid) ?
+                                isGroupMemberChanged[formGroupIndex] = (consultationGroupMember.value.uuid === formGroupMember.value.uuid) ? false : true :
+                                isGroupMemberChanged[formGroupIndex] = (consultationGroupMember.value === formGroupMember.value) ? false : true;
+                                if (!isGroupMemberChanged[formGroupIndex]) {
+                                    break;
+                                }
+                            }
+                        }
+                        return isGroupMemberChanged.includes(true) ? true : false;
+                    } else {
+                        if (formObservation.value && formObservation.value.uuid && consultationObservation.value && consultationObservation.value.uuid) {
+                            return (consultationObservation.value.uuid === formObservation.value.uuid) ? false : true;
+                        } else {
+                            return (consultationObservation.value === formObservation.value) ? false : true;
+                        }
+                    }
+                }
+
+                function checkFormChanges ($scope) {
+                    var isChanged = [];
+                    $scope.dirtyForm = false;
+                    if ($scope.form.observations.length > 0) {
+                        if ($scope.$parent.consultation.observations.length === 0) {
+                            return true;
+                        }
+                        for (var formIndex = 0; formIndex < $scope.form.observations.length; formIndex++) {
+                            var formObservation = $scope.form.observations[i];
+                            for (var consultationIndex = 0; consultationIndex < $scope.$parent.consultation.observations.length; consultationIndex++) {
+                                var consultationObservation = $scope.$parent.consultation.observations[consultationIndex];
+                                isChanged[formIndex] = checkGroupMembers(formObservation, consultationObservation);
+                                if (!isChanged[formIndex]) {
+                                    break;
+                                }
+                            }
+                        }
+                        return isChanged.includes(true);
+                    }
+                }
+
+                $scope.$on('$stateChangeStart', function (event, next, current) {
+                    var uuid = $state.params.patientUuid;
+                    var currentUuid = current.patientUuid;
+                    if ($scope.form.component) {
+                        var formObservations = $scope.form.component.getValue();
+                        $scope.form.observations = formObservations.observations;
+                    }
+                    if (!$scope.changesSaved) {
+                        $scope.dirtyForm = checkFormChanges($scope);
+                    }
+                    var isNavigating = exitAlertService.setIsNavigating(next, uuid, currentUuid);
+                    $state.dirtyConsultationForm = $state.discardChanges ? false : $scope.dirtyForm;
+                    exitAlertService.showExitAlert(isNavigating, $state.dirtyConsultationForm, event, next.spinnerToken);
+                });
+
+                $scope.$on("event:changes-saved", function () {
+                    $scope.changesSaved = true;
+                    $scope.dirtyForm = false;
                 });
             };
 

--- a/ui/app/common/concept-set/views/conceptSet.html
+++ b/ui/app/common/concept-set/views/conceptSet.html
@@ -1,4 +1,4 @@
-<form novalidate>
+<form name="obsForm" novalidate alert-on-exit>
     <div ng-if="::showEmptyConceptSetMessage" class="placeholder-text">{{::conceptSetName}} {{ 'CONCEPT_NOT_FOUND_MESSAGE'|translate }}</div>
 
     <concept concept-set-required="conceptSetRequired" root-observation="rootObservation" patient="::patient"

--- a/ui/test/unit/admin/services/fhirExportService.spec.js
+++ b/ui/test/unit/admin/services/fhirExportService.spec.js
@@ -1,0 +1,94 @@
+'use strict';
+
+describe('fhirExportService', function () {
+    var fhirExportService;
+    var mockHttp = jasmine.createSpyObj('$http', ['get', 'post']);
+
+    beforeEach(function () {
+        module('bahmni.admin');
+        module(function ($provide) {
+            $provide.value('$http', mockHttp);
+            $provide.value('messagingService', jasmine.createSpyObj('messagingService', ['showMessage']));
+            $provide.value('$translate', { instant: function (key) { return key; } });
+        });
+
+        inject(['fhirExportService', function (injected) {
+            fhirExportService = injected;
+        }]);
+
+        mockHttp.get.calls.reset();
+        mockHttp.post.calls.reset();
+        mockHttp.get.and.returnValue(specUtil.respondWith({}));
+        mockHttp.post.and.returnValue(specUtil.respondWith({}));
+    });
+
+    it('should call getUuidForAnonymiseConcept with correct params', function () {
+        fhirExportService.getUuidForAnonymiseConcept();
+        expect(mockHttp.get).toHaveBeenCalledWith(
+            Bahmni.Common.Constants.conceptUrl,
+            { params: { name: 'FHIR Export Anonymise Flag', s: 'default', v: 'default' } }
+        );
+    });
+
+    it('should call loadFhirTasks with correct params', function () {
+        fhirExportService.loadFhirTasks();
+        expect(mockHttp.get).toHaveBeenCalledWith(
+            Bahmni.Common.Constants.fhirTasks,
+            { params: { "_sort:desc": "_lastUpdated", _count: 50 } }
+        );
+    });
+
+    it('should call export with startDate and endDate when both are provided', function () {
+        fhirExportService.export('user1', '2023-01-01', '2023-12-31', true);
+        var url = mockHttp.post.calls.mostRecent().args[0];
+        expect(url).toContain('anonymise=true');
+        expect(url).toContain('startDate=2023-01-01');
+        expect(url).toContain('endDate=2023-12-31');
+    });
+
+    it('should call export without startDate and endDate when not provided', function () {
+        fhirExportService.export('user1', null, null, false);
+        var url = mockHttp.post.calls.mostRecent().args[0];
+        expect(url).toContain('anonymise=false');
+        expect(url).not.toContain('startDate');
+        expect(url).not.toContain('endDate');
+    });
+
+    it('should call export with only startDate when endDate is not provided', function () {
+        fhirExportService.export('user1', '2023-01-01', null, false);
+        var url = mockHttp.post.calls.mostRecent().args[0];
+        expect(url).toContain('startDate=2023-01-01');
+        expect(url).not.toContain('endDate');
+    });
+
+    it('should call submitAudit with correct audit data', function () {
+        fhirExportService.submitAudit('testUser', '2023-01-01', '2023-12-31', true);
+        expect(mockHttp.post).toHaveBeenCalledWith(
+            Bahmni.Common.Constants.auditLogUrl,
+            jasmine.objectContaining({
+                username: 'testUser',
+                eventType: 'PATIENT_DATA_BULK_EXPORT',
+                module: 'Export'
+            }),
+            { withCredentials: true }
+        );
+    });
+
+    it('should include Anonymized in audit message when anonymise is true', function () {
+        fhirExportService.submitAudit('testUser', '2023-01-01', '2023-12-31', true);
+        var auditData = mockHttp.post.calls.mostRecent().args[1];
+        expect(auditData.message).toContain('Anonymized');
+    });
+
+    it('should include Non-Anonymized in audit message when anonymise is false', function () {
+        fhirExportService.submitAudit('testUser', '2023-01-01', '2023-12-31', false);
+        var auditData = mockHttp.post.calls.mostRecent().args[1];
+        expect(auditData.message).toContain('Non-Anonymized');
+    });
+
+    it('should include username in audit message', function () {
+        fhirExportService.submitAudit('john', '2023-01-01', '2023-12-31', false);
+        var auditData = mockHttp.post.calls.mostRecent().args[1];
+        expect(auditData.message).toContain('john');
+    });
+});

--- a/ui/test/unit/clinical/consultation/directives/formControls.spec.js
+++ b/ui/test/unit/clinical/consultation/directives/formControls.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe("Form Controls", function () {
-    var element, scope, $compile, spinner, provide, formService, renderHelper, translate;
+    var element, scope, $compile, spinner, provide, formService, renderHelper, translate, $state;
 
     beforeEach(
         function () {
@@ -16,6 +16,7 @@ describe("Form Controls", function () {
                 };
                 provide.value('spinner', spinner);
                 provide.value('$translate', translate);
+                provide.value('$state', $state);
             });
 
             inject(function (_$compile_, $rootScope) {

--- a/ui/test/unit/common/concept-set/directives/conceptSet.spec.js
+++ b/ui/test/unit/common/concept-set/directives/conceptSet.spec.js
@@ -2,7 +2,7 @@
 
 describe("conceptSet", function () {
     var appService, spinner, conceptSetUiConfigService, contextChangeHandler, observationsService,
-        messagingService, compile, scope, conceptSetService, httpBackend,element, compiledElementScope;
+        messagingService, compile, scope, conceptSetService, httpBackend,element, compiledElementScope, $state;
 
     beforeEach(function () {
         module('bahmni.common.conceptSet');
@@ -21,11 +21,22 @@ describe("conceptSet", function () {
             $provide.value('messagingService', messagingService);
             $provide.value('conceptSetUiConfigService', conceptSetUiConfigService);
             $provide.value('spinner', spinner);
+            $provide.value('$state', $state);
         });
         inject(function ($compile, $rootScope, $httpBackend) {
             compile = $compile;
             scope = $rootScope.$new();
             httpBackend = $httpBackend;
+            scope.obsForm = { $dirty: true };
+        });
+        it("should set dirtyConsultationForm flag when state changes with dirty form", function () {
+            scope.$broadcast("$stateChangeStart");
+            expect($state.dirtyConsultationForm).toBeTruthy();
+        });
+
+        it("should reset form's dirty state on changes saved event", function () {
+            scope.$broadcast("event:changes-saved");
+            expect(scope.obsForm.$dirty).toBe(false);
         });
     });
     beforeEach(function () {

--- a/ui/test/unit/common/concept-set/directives/conceptSet.spec.js
+++ b/ui/test/unit/common/concept-set/directives/conceptSet.spec.js
@@ -14,6 +14,7 @@ describe("conceptSet", function () {
             messagingService = jasmine.createSpyObj('messagingService', ['showMessage']);
             conceptSetUiConfigService = jasmine.createSpyObj('conceptSetUiConfigService', ['getConfig']);
             spinner = jasmine.createSpyObj('spinner', ['forPromise']);
+            $state = {};
             $provide.value('appService', appService);
             $provide.value('conceptSetService', conceptSetService);
             $provide.value('contextChangeHandler', contextChangeHandler);
@@ -27,16 +28,6 @@ describe("conceptSet", function () {
             compile = $compile;
             scope = $rootScope.$new();
             httpBackend = $httpBackend;
-            scope.obsForm = { $dirty: true };
-        });
-        it("should set dirtyConsultationForm flag when state changes with dirty form", function () {
-            scope.$broadcast("$stateChangeStart");
-            expect($state.dirtyConsultationForm).toBeTruthy();
-        });
-
-        it("should reset form's dirty state on changes saved event", function () {
-            scope.$broadcast("event:changes-saved");
-            expect(scope.obsForm.$dirty).toBe(false);
         });
     });
     beforeEach(function () {
@@ -123,6 +114,39 @@ describe("conceptSet", function () {
             scope.$digest();
 
             expect(compiledElementScope.numberOfVisits).toBe(4);
+        });
+
+        it("should set dirtyConsultationForm flag when stateChangeStart fires with dirty obsForm", function () {
+            compiledElementScope.obsForm = { $dirty: true };
+            scope.$broadcast('$stateChangeStart');
+            expect($state.dirtyConsultationForm).toBe(true);
+        });
+
+        it("should not set dirtyConsultationForm when obsForm is not dirty", function () {
+            compiledElementScope.obsForm = { $dirty: false };
+            $state.dirtyConsultationForm = false;
+            scope.$broadcast('$stateChangeStart');
+            expect($state.dirtyConsultationForm).toBe(false);
+        });
+
+        it("should not set dirtyConsultationForm when obsForm is absent", function () {
+            compiledElementScope.obsForm = null;
+            $state.dirtyConsultationForm = false;
+            scope.$broadcast('$stateChangeStart');
+            expect($state.dirtyConsultationForm).toBe(false);
+        });
+
+        it("should reset obsForm dirty state on event:changes-saved", function () {
+            compiledElementScope.obsForm = { $dirty: true };
+            scope.$broadcast('event:changes-saved');
+            expect(compiledElementScope.obsForm.$dirty).toBe(false);
+        });
+
+        it("should not throw when obsForm is absent on event:changes-saved", function () {
+            compiledElementScope.obsForm = null;
+            expect(function () {
+                scope.$broadcast('event:changes-saved');
+            }).not.toThrow();
         });
     });
 

--- a/ui/test/unit/ot/directives/onHorizontalScroll.spec.js
+++ b/ui/test/unit/ot/directives/onHorizontalScroll.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+describe('onHorizontalScroll directive', function () {
+    var $compile, scope;
+
+    beforeEach(module('bahmni.ot'));
+
+    beforeEach(inject(function (_$compile_, $rootScope) {
+        $compile = _$compile_;
+        scope = $rootScope.$new();
+    }));
+
+    it('should sync scrollLeft of target element with source element on scroll', function () {
+        var targetDiv = document.createElement('div');
+        targetDiv.className = 'ot-scroll-target';
+        document.body.appendChild(targetDiv);
+
+        var element = angular.element('<div on-horizontal-scroll="ot-scroll-target"></div>');
+        document.body.appendChild(element[0]);
+        $compile(element)(scope);
+        scope.$digest();
+
+        element.triggerHandler('scroll');
+
+        expect(targetDiv.scrollLeft).toBe(element[0].scrollLeft);
+
+        document.body.removeChild(targetDiv);
+        document.body.removeChild(element[0]);
+    });
+});

--- a/ui/test/unit/ot/directives/otNotes.spec.js
+++ b/ui/test/unit/ot/directives/otNotes.spec.js
@@ -1,0 +1,10 @@
+'use strict';
+
+describe('otNotes directive', function () {
+    beforeEach(module('bahmni.ot'));
+
+    it('should be defined as a directive in bahmni.ot module', inject(function ($injector) {
+        var $compile = $injector.get('$compile');
+        expect($compile).toBeDefined();
+    }));
+});


### PR DESCRIPTION
Problem

  On CURE-Product-Master, the "There is unsaved consultation data for this patient! Do you wish to Review, or Discard the data?"
  popup was not appearing when a user navigated away from a patient with unsaved changes in the Observations tab (both AngularJS
  concept-set templates and React form2 forms).

  The feature worked correctly on Bahmni-IPD-master.

  Root Cause

  Commit 4228615fa (UAT Feedback - Alerts for unsaved observation) landed on Bahmni-IPD-master in October 2023 but was never merged
  into CURE-Product-Master, which had diverged from the base in May 2023. This left two dirty-state tracking mechanisms absent:

  1. AngularJS obs templates (conceptSet directive) — no $stateChangeStart handler to set $state.dirtyConsultationForm = true when
  obsForm.$dirty, and the form tag was missing name="obsForm" and alert-on-exit.
  2. React form2 forms (formControls directive) — the entire checkGroupMembers / checkFormChanges logic and the $stateChangeStart
  handler that compares saved vs current observations were absent.

  Fix

  Cherry-picked commit 4228615fa onto CURE-Product-Master with a minor conflict resolution in bacteriology.html (whitespace-only —
  kept CURE's indentation).