### PR TITLE
HIVE-108160: Vivek: fix: ReferenceError on checkFormChanges on patient dashboard navigation and program page error

### DIFF
--- a/ui/app/common/patient-search/controllers/patientsListController.js
+++ b/ui/app/common/patient-search/controllers/patientsListController.js
@@ -255,7 +255,7 @@ angular.module('bahmni.common.patientSearch')
                 newTab: true
             } : {url: $scope.search.searchType.forwardUrl, newTab: false};
             if ($scope.search.searchType.links) {
-                link = _.find($scope.search.searchType.links, {linkColumn: heading}) || _.find($scope.search.searchType.links, { linkColumn: heading.name }) || link;
+                link = _.find($scope.search.searchType.links, {linkColumn: heading}) || _.find($scope.search.searchType.links, {linkColumn: heading && heading.name}) || link;
             }
             if ($scope.search.searchType.targetedTab) {
                 link.targetedTab = $scope.search.searchType.targetedTab;

--- a/ui/test/unit/adt/directives/bedAssignmentDialog.spec.js
+++ b/ui/test/unit/adt/directives/bedAssignmentDialog.spec.js
@@ -1,0 +1,24 @@
+describe('bedAssignmentDialog directive', function () {
+    var $compile, $rootScope, $document;
+    beforeEach(module('bahmni.adt'));
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$document_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $document = _$document_;
+    }));
+    it('should set bed details and position the bed info element', function () {
+        var scope = $rootScope.$new();
+        var element = angular.element('<div bed-assignment-dialog></div>');
+        $compile(element)(scope);
+        scope.cell = {
+            bed: {
+                bedId: 1,
+                bedNumber: '1'
+            }
+        };
+        scope.setBedDetails = jasmine.createSpy('setBedDetails');
+
+        element.triggerHandler('click');   
+        expect(scope.setBedDetails).toHaveBeenCalledWith(scope.cell);
+    });
+});

--- a/ui/test/unit/clinical/consultation/directives/formControls.spec.js
+++ b/ui/test/unit/clinical/consultation/directives/formControls.spec.js
@@ -10,6 +10,10 @@ describe("Form Controls", function () {
                 provide = $provide;
                 formService = jasmine.createSpyObj('formService', ['getFormDetail', 'getFormTranslations']);
                 spinner = jasmine.createSpyObj('spinner', ['forPromise']);
+                $state = {
+                    patientUuid: 'patientUuid',
+                    dirtyConsultationForm: false
+                };
                 provide.value('formService', formService);
                 translate = {
                     use: function(){ return 'en' }
@@ -19,9 +23,10 @@ describe("Form Controls", function () {
                 provide.value('$state', $state);
             });
 
-            inject(function (_$compile_, $rootScope) {
+            inject(function (_$compile_, $rootScope, _$state_) {
                 $compile = _$compile_;
                 scope = $rootScope.$new();
+                $state = _$state_;
             });
 
             renderHelper = {
@@ -80,6 +85,15 @@ describe("Form Controls", function () {
         mockObservationService({ resources: [{ value: '{"name":"Vitals", "controls": [{"type":"obsControl", "controls":[]}] }' }] });
         createElement();
         expect(renderHelper.renderWithControlsCalledTimes).toBe(2);
+    });
+
+    it("should set dirtyForm flag when changes are saved", function () {
+        mockObservationService({ resources: [{ value: '{"name":"Vitals", "controls": [{"type":"obsControl", "controls":[]}] }' }] });
+        createElement();
+        scope.$digest();
+
+        scope.$broadcast("$event:changes-saved");
+        expect($state.dirtyForm).toBeFalsy();
     });
 
     var createElement = function () {

--- a/ui/test/unit/common/ui-helper/directives/autoScroll.spec.js
+++ b/ui/test/unit/common/ui-helper/directives/autoScroll.spec.js
@@ -1,0 +1,35 @@
+'use strict';
+
+describe('autoScroll', function () {
+    var element, scope, compile, $timeout;
+
+    beforeEach(module('bahmni.common.uiHelper'));
+
+    beforeEach(inject(function ($rootScope, $compile, _$timeout_) {
+        scope = $rootScope.$new();
+        compile = $compile;
+        $timeout = _$timeout_;
+        spyOn($.fn, 'animate');
+        spyOn($.fn, 'offset').and.returnValue({ top: 100 });
+    }));
+
+    it('should call animate when autoScrollEnabled is true', function () {
+        scope.enabled = true;
+        element = angular.element('<div auto-scroll auto-scroll-enabled="enabled"></div>');
+        compile(element)(scope);
+        scope.$digest();
+        $timeout.flush();
+
+        expect($.fn.animate).toHaveBeenCalled();
+    });
+
+    it('should not call animate when autoScrollEnabled is false', function () {
+        scope.enabled = false;
+        element = angular.element('<div auto-scroll auto-scroll-enabled="enabled"></div>');
+        compile(element)(scope);
+        scope.$digest();
+        $timeout.flush();
+
+        expect($.fn.animate).not.toHaveBeenCalled();
+    });
+});

--- a/ui/test/unit/common/ui-helper/filters/formatDecimalValues.spec.js
+++ b/ui/test/unit/common/ui-helper/filters/formatDecimalValues.spec.js
@@ -1,0 +1,25 @@
+'use strict';
+
+describe('Filter: formatDecimalValues', function () {
+    var formatDecimalValuesFilter;
+
+    beforeEach(module('bahmni.common.uiHelper'));
+    beforeEach(inject(function ($filter) {
+        formatDecimalValuesFilter = $filter('formatDecimalValues');
+    }));
+
+    it('should return null when value is falsy', function () {
+        expect(formatDecimalValuesFilter(null)).toBeNull();
+        expect(formatDecimalValuesFilter(undefined)).toBeNull();
+        expect(formatDecimalValuesFilter('')).toBeNull();
+    });
+
+    it('should strip trailing .0 followed by whitespace', function () {
+        expect(formatDecimalValuesFilter('5.0 mg')).toEqual('5 mg');
+    });
+
+    it('should return value unchanged when no .0 followed by whitespace', function () {
+        expect(formatDecimalValuesFilter('5.5 mg')).toEqual('5.5 mg');
+        expect(formatDecimalValuesFilter('5.0')).toEqual('5.0');
+    });
+});

--- a/ui/test/unit/common/ui-helper/filters/reverse.spec.js
+++ b/ui/test/unit/common/ui-helper/filters/reverse.spec.js
@@ -1,0 +1,25 @@
+'use strict';
+
+describe('Filter: reverse', function () {
+    var reverseFilter;
+
+    beforeEach(module('bahmni.common.uiHelper'));
+    beforeEach(inject(function ($filter) {
+        reverseFilter = $filter('reverse');
+    }));
+
+    it('should return items in reverse order', function () {
+        expect(reverseFilter([1, 2, 3])).toEqual([3, 2, 1]);
+    });
+
+    it('should return null/undefined when items is falsy', function () {
+        expect(reverseFilter(null)).toBeFalsy();
+        expect(reverseFilter(undefined)).toBeFalsy();
+    });
+
+    it('should not mutate the original array', function () {
+        var original = [1, 2, 3];
+        reverseFilter(original);
+        expect(original).toEqual([1, 2, 3]);
+    });
+});

--- a/ui/test/unit/common/util/genderUtil.spec.js
+++ b/ui/test/unit/common/util/genderUtil.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+describe('GenderUtil', function () {
+    var genderUtil = Bahmni.Common.Util.GenderUtil;
+
+    describe('translateGender', function () {
+        it('should update genderMap entry when translation exists', function () {
+            var genderMap = { M: 'Male', F: 'Female' };
+            var $translate = {
+                instant: function (key) {
+                    return key === 'GENDER_M' ? 'Male (translated)' : key;
+                }
+            };
+
+            genderUtil.translateGender(genderMap, $translate);
+
+            expect(genderMap.M).toEqual('Male (translated)');
+            expect(genderMap.F).toEqual('Female');
+        });
+
+        it('should not update genderMap entry when translation key is returned unchanged', function () {
+            var genderMap = { M: 'Male' };
+            var $translate = {
+                instant: function (key) {
+                    return key;
+                }
+            };
+
+            genderUtil.translateGender(genderMap, $translate);
+
+            expect(genderMap.M).toEqual('Male');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
  - Fixes `ReferenceError: i is not defined` error shown as red notification when navigating back to the patient dashboard after
  submitting an observation form
  Cherry-picked commit `5fdac8263` from `Bahmni-IPD-master` which fixes the typo in `checkFormChanges` (`observations[i]` →
  `observations[formIndex]`) and inlines the `exitAlertService` navigation logic directly into `formControls.js`
  
  - Also fixes a bug on the programs page where clicking the name field caused an error

