### PR TITLE
Vivek: HIVE-108160: fix: restore exitAlertService in formControls

### DIFF
--- a/ui/app/common/concept-set/directives/formControls.js
+++ b/ui/app/common/concept-set/directives/formControls.js
@@ -1,7 +1,8 @@
 'use strict';
+
 angular.module('bahmni.common.conceptSet')
-    .directive('formControls', ['formService', 'spinner', '$timeout', '$translate', '$state', 'messagingService',
-        function (formService, spinner, $timeout, $translate, $state, messagingService) {
+    .directive('formControls', ['formService', 'spinner', '$timeout', '$translate', '$state', 'messagingService', 'exitAlertService',
+        function (formService, spinner, $timeout, $translate, $state, messagingService, exitAlertService) {
             var loadedFormDetails = {};
             var loadedFormTranslations = {};
             var unMountReactContainer = function (formUuid) {
@@ -10,6 +11,7 @@ angular.module('bahmni.common.conceptSet')
                     unMountForm(document.getElementById(formUuid));
                 });
             };
+
             var controller = function ($scope) {
                 var formUuid = $scope.form.formUuid;
                 var formVersion = $scope.form.formVersion;
@@ -18,6 +20,7 @@ angular.module('bahmni.common.conceptSet')
                 var collapse = $scope.form.collapseInnerSections && $scope.form.collapseInnerSections.value;
                 var validateForm = $scope.validateForm || false;
                 var locale = $translate.use();
+
                 if (!loadedFormDetails[formUuid]) {
                     spinner.forPromise(formService.getFormDetail(formUuid, { v: "custom:(resources:(value))" })
                         .then(function (response) {
@@ -53,6 +56,7 @@ angular.module('bahmni.common.conceptSet')
                         unMountReactContainer($scope.form.formUuid);
                     }, 0, false);
                 }
+
                 $scope.$watch('form.collapseInnerSections', function () {
                     var collapse = $scope.form.collapseInnerSections && $scope.form.collapseInnerSections.value;
                     if (loadedFormDetails[formUuid]) {
@@ -60,11 +64,13 @@ angular.module('bahmni.common.conceptSet')
                             formUuid, collapse, $scope.patient, validateForm, locale, loadedFormTranslations[formUuid]);
                     }
                 });
+
                 $scope.$on('$destroy', function () {
                     if ($scope.$parent.consultation && $scope.$parent.consultation.observationForms) {
                         if ($scope.form.component) {
                             var formObservations = $scope.form.component.getValue();
                             $scope.form.observations = formObservations.observations;
+
                             var hasError = formObservations.errors;
                             if (!_.isEmpty(hasError)) {
                                 $scope.form.isValid = false;
@@ -96,6 +102,7 @@ angular.module('bahmni.common.conceptSet')
                         }
                     }
                 }
+
                 function checkFormChanges ($scope) {
                     var isChanged = [];
                     $scope.dirtyForm = false;
@@ -116,6 +123,7 @@ angular.module('bahmni.common.conceptSet')
                         return isChanged.includes(true);
                     }
                 }
+
                 $scope.$on('$stateChangeStart', function (event, next, current) {
                     var uuid = $state.params.patientUuid;
                     var currentUuid = current.patientUuid;
@@ -126,22 +134,17 @@ angular.module('bahmni.common.conceptSet')
                     if (!$scope.changesSaved) {
                         $scope.dirtyForm = checkFormChanges($scope);
                     }
-                    $state.newPatientUuid = currentUuid;
-                    next.url.includes("/patient/search") ? $state.isPatientSearch = true : $state.isPatientSearch = false;
-                    var isNavigating = next.url.includes("/patient/search") || (uuid !== currentUuid);
+                    var isNavigating = exitAlertService.setIsNavigating(next, uuid, currentUuid);
                     $state.dirtyConsultationForm = $state.discardChanges ? false : $scope.dirtyForm;
-                    if (isNavigating && $state.dirtyConsultationForm) {
-                        messagingService.showMessage('alert', "{{'ALERT_MESSAGE_ON_EXIT' | translate }}");
-                        $state.reviewButtonFocused = true;
-                        event.preventDefault();
-                        spinner.hide(next.spinnerToken);
-                    }
+                    exitAlertService.showExitAlert(isNavigating, $state.dirtyConsultationForm, event, next.spinnerToken);
                 });
+
                 $scope.$on("event:changes-saved", function () {
                     $scope.changesSaved = true;
                     $scope.dirtyForm = false;
                 });
             };
+
             return {
                 restrict: 'E',
                 scope: {


### PR DESCRIPTION
This restores exitAlertService for navigation change detection (accidentally removed in d28f530), while retaining the formIndex
  off-by-one fix and the heading && heading.name null-safe fix from that commit.