### PR TITLE
Pooja | Hive-109060 | Add new capability: Disable Save as Draft button until the form is dirty

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -62,6 +62,7 @@ angular.module('bahmni.clinical')
                         openTemplate(templateToBeOpened);
                     }
                 }
+                $timeout(setupDirtyTracking, 0);
             };
 
             var addTemplatesInSavedOrder = function () {
@@ -291,13 +292,89 @@ angular.module('bahmni.clinical')
                 showSpinner: false,
                 statusMessage: null,
                 statusParams: {},
-                statusError: false
+                statusError: false,
+                isDirty: false
             };
 
-            $scope.saveAsDraft = function () {
-                $scope.formDraft.showSpinner = true;
-                $scope.formDraft.statusMessage = null;
+            var cleanState = null;
+            var dirtyTrackingInitialized = false;
+            var dirtyTrackingSyncPromise;
+
+            var updateDirtyState = function (currentState) {
+                $scope.formDraft.isDirty = currentState !== cleanState;
+            };
+
+            var getTemplateObservationsForDirtyTracking = function (template) {
+                if (template.component && angular.isFunction(template.component.getValue)) {
+                    var formValue = template.component.getValue() || {};
+                    if (formValue.observations) {
+                        return formValue.observations;
+                    }
+                }
+                return template.observations || [];
+            };
+
+            var collectObsValues = function (obs, values) {
+                if (!obs) {
+                    return;
+                }
+                if (obs.isMultiSelect) {
+                    var selectedKeys = _.keys(obs.selectedObs || {}).filter(function (k) {
+                        return k.indexOf('$') !== 0;
+                    });
+                    if (selectedKeys.length > 0) {
+                        values.push(obs.selectedObs);
+                    }
+                    return;
+                }
+                if (obs.groupMembers && obs.groupMembers.length > 0) {
+                    _.each(obs.groupMembers, function (member) {
+                        collectObsValues(member, values);
+                    });
+                    return;
+                }
+                if (obs.value !== null && obs.value !== undefined) {
+                    values.push(obs.value);
+                }
+            };
+
+            var getObsValues = function () {
+                var values = [];
+                if ($scope.consultation.selectedObsTemplate) {
+                    _.each($scope.consultation.selectedObsTemplate, function (template) {
+                        var observations = getTemplateObservationsForDirtyTracking(template);
+                        if (observations.length > 0) {
+                            _.each(observations, function (obs) {
+                                collectObsValues(obs, values);
+                            });
+                        }
+                    });
+                }
+                return angular.toJson(values);
+            };
+
+            var syncDirtyState = function () {
+                updateDirtyState(getObsValues());
+                dirtyTrackingSyncPromise = $timeout(syncDirtyState, 500);
+            };
+
+            var setupDirtyTracking = function () {
+                if (dirtyTrackingInitialized) {
+                    return;
+                }
+                dirtyTrackingInitialized = true;
+                cleanState = getObsValues();
+                $scope.$watch(getObsValues, function (newVal, oldVal) {
+                    if (newVal !== oldVal) {
+                        updateDirtyState(newVal);
+                    }
+                });
+                syncDirtyState();
+            };
+
+            var saveFormDraft = function () {
                 $scope.formDraft.statusError = false;
+                $scope.formDraft.showSpinner = true;
 
                 $timeout(function () {
                     if (saveAsDraftSuccess) {
@@ -308,6 +385,8 @@ angular.module('bahmni.clinical')
                         $scope.formDraft.statusParams = {draftDate: draftDate, draftTime: draftTime};
                         $scope.formDraft.draftDate = draftDate;
                         $scope.formDraft.draftTime = draftTime;
+                        $scope.formDraft.isDirty = false;
+                        cleanState = getObsValues();
                         // Broadcast event to update parent scope's draft date and time - update this during API integration
                         $rootScope.$broadcast('draft:saved', {draftDate: draftDate, draftTime: draftTime});
                     } else {
@@ -319,6 +398,14 @@ angular.module('bahmni.clinical')
                     saveAsDraftSuccess = !saveAsDraftSuccess;
                 }, 2000);
             };
+
+            $scope.saveAsDraft = saveFormDraft;
+
+            $scope.$on('$destroy', function () {
+                if (dirtyTrackingSyncPromise) {
+                    $timeout.cancel(dirtyTrackingSyncPromise);
+                }
+            });
 
             init();
         }]);

--- a/ui/app/clinical/consultation/views/conceptSet.html
+++ b/ui/app/clinical/consultation/views/conceptSet.html
@@ -6,14 +6,16 @@
                     <div class="template-control-panel-right">
                         <div class="template-control-panel" >
                             <div class="template-control-panel-button">
-                                <div class="saving-draft-indicator" ng-show="formDraft.showSpinner && enableFormDraftFeature">
-                                    <div class="carbon-loader">
-                                        <div class="loader-circle"></div>
+                                <div class="draft-feedback-area" ng-show="enableFormDraftFeature">
+                                    <div class="saving-draft-indicator" ng-show="formDraft.showSpinner">
+                                        <div class="carbon-loader">
+                                            <div class="loader-circle"></div>
+                                        </div>
+                                        <span class="saving-text">{{::'SAVING_AS_DRAFT' | translate }}</span>
                                     </div>
-                                    <span class="saving-text">{{::'SAVING_AS_DRAFT' | translate }}</span>
+                                    <span class="draft-status-text" ng-show="!formDraft.showSpinner && formDraft.statusMessage" ng-class="{'draft-status-error': formDraft.statusError}">{{ formDraft.statusMessage | translate: formDraft.statusParams }}</span>
                                 </div>
-                                <span class="draft-status-text" ng-show="formDraft.statusMessage && enableFormDraftFeature" ng-class="{'draft-status-error': formDraft.statusError}">{{ formDraft.statusMessage | translate: formDraft.statusParams }}</span>
-                                <button id="save-as-draft-button" class="save-draft-button" ng-click="saveAsDraft()" ng-show="enableFormDraftFeature">{{::'SAVE_AS_DRAFT'  | translate }}</button>
+                                <button id="save-as-draft-button" class="save-draft-button" ng-click="saveAsDraft()" ng-show="enableFormDraftFeature" ng-disabled="!formDraft.isDirty">{{::'SAVE_AS_DRAFT'  | translate }}</button>
                                 <button id="template-control-panel-button" class="fr" bm-pop-over-trigger>{{::'ADD_NEW_OBSERVATION'  | translate }}</button>
                             </div>
                             <div class="primary-section-grid" bm-pop-over-target>

--- a/ui/app/styles/bahmni-components/_templateController.scss
+++ b/ui/app/styles/bahmni-components/_templateController.scss
@@ -226,6 +226,22 @@
     }
 }
 
+.template-control .template-control-panel-button .draft-feedback-area {
+    display: inline-block;
+    vertical-align: middle;
+    min-width: 180px;
+    text-align: right;
+    margin-right: 10px;
+
+    .saving-draft-indicator {
+        margin-right: 0;
+    }
+
+    .draft-status-text {
+        margin-right: 0;
+    }
+}
+
 .template-control .template-control-panel-button .saving-draft-indicator {
     display: inline-flex;
     align-items: center;

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -556,4 +556,76 @@ describe('ConceptSetPageController', function () {
             expect(appService.getAppDescriptor).toHaveBeenCalled();
         });
     })
+
+    describe('Save As Draft', function () {
+        var createControllerWithTimeoutAndFilter;
+
+        beforeEach(inject(function ($timeout) {
+            createControllerWithTimeoutAndFilter = function (timeoutMock, filterMock) {
+                var defaultFilterMock = function () {
+                    return function () {
+                        return 'mocked-time';
+                    };
+                };
+                clinicalAppConfigService.getAllConceptSetExtensions.and.returnValue(extension);
+                return controller("ConceptSetPageController", {
+                    $scope: scope,
+                    $rootScope: rootScope,
+                    $stateParams: stateParams,
+                    conceptSetService: conceptSetService,
+                    formService: formService,
+                    clinicalAppConfigService: clinicalAppConfigService,
+                    messagingService: messagingService,
+                    configurations: configurations,
+                    $state: state,
+                    spinner: spinner,
+                    $translate: translate,
+                    appService: appService,
+                    $timeout: timeoutMock || $timeout,
+                    $filter: filterMock || defaultFilterMock
+                });
+            };
+        }));
+
+        it('should set dirty true when form component observation changes', function () {
+            var conceptResponseData = {
+                results: [
+                    {
+                        setMembers: [{name: {name: 'abcd'}, uuid: 123}]
+                    }
+                ]
+            };
+            mockConceptSetService(conceptResponseData);
+            mockformService({});
+
+            var observationValue;
+            var timeoutMock = function (callback, delay) {
+                if (delay === 0) {
+                    callback();
+                }
+                return {$$timeoutId: delay};
+            };
+            timeoutMock.cancel = jasmine.createSpy('cancel');
+
+            createControllerWithTimeoutAndFilter(timeoutMock);
+
+            scope.consultation.selectedObsTemplate = [{
+                component: {
+                    getValue: function () {
+                        return {
+                            observations: [{value: observationValue}]
+                        };
+                    }
+                },
+                observations: []
+            }];
+
+            scope.$digest();
+            expect(scope.formDraft.isDirty).toBe(false);
+
+            observationValue = 'updated-value';
+            scope.$digest();
+            expect(scope.formDraft.isDirty).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
Update based on feedback: 
The Save As Draft will be disabled when the form is not touched upon by the user yet. Once user makes changes in the form, button will be enabled. And when Save As Draft is clicked, it'll be immediately disabled, until user makes further changes to it.