### PR TITLE
Feature 111796 resume draft

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -61,6 +61,10 @@ angular.module('bahmni.clinical')
                         openTemplate(templateToBeOpened);
                     }
                 }
+                if ($rootScope.resumeDraftOnLoad && $rootScope.draftData && $rootScope.draftData.formData) {
+                    populateFormWithDraftData($rootScope.draftData.formData);
+                    $rootScope.resumeDraftOnLoad = false;
+                }
                 $timeout(setupDirtyTracking, 0);
             };
 

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -36,15 +36,33 @@ angular.module('bahmni.clinical')
                             spinner.forPromise(formService.getFormList($scope.consultation.encounterUuid)
                                 .then(function (response) {
                                     $scope.consultation.observationForms = getObservationForms(response.data);
-                                    concatObservationForms();
+                                    loadDraftThenConcat();
                                 })
                             );
                         } else {
-                            concatObservationForms();
+                            loadDraftThenConcat();
                         }
                     }));
                 }
             };
+            var loadDraftThenConcat = function () {
+                var patientUuid = $scope.patient ? $scope.patient.uuid : null;
+                var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
+                if ($scope.enableFormDraftFeature && !$rootScope.resumeDraftOnLoad && patientUuid && providerUuid) {
+                    formDraftService.getDraft(patientUuid, providerUuid).then(function (response) {
+                        if (response.data && response.data.uuid && !response.data.markedAsSaved) {
+                            $rootScope.draftData = response.data;
+                            $rootScope.resumeDraftOnLoad = true;
+                        }
+                        concatObservationForms();
+                    }, function () {
+                        concatObservationForms();
+                    });
+                } else {
+                    concatObservationForms();
+                }
+            };
+
             var concatObservationForms = function () {
                 $scope.allTemplates = getSelectedObsTemplate(allConceptSections);
                 $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -49,10 +49,14 @@ angular.module('bahmni.clinical')
                 var patientUuid = $scope.patient ? $scope.patient.uuid : null;
                 var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
                 if ($scope.enableFormDraftFeature && !$rootScope.resumeDraftOnLoad && patientUuid && providerUuid) {
-                    formDraftService.getDraft(patientUuid, providerUuid).then(function (response) {
-                        if (response.data && response.data.uuid && !response.data.markedAsSaved) {
+                    var promise = draftCheckPromise || formDraftService.getDraft(patientUuid, providerUuid);
+                    promise.then(function (response) {
+                        if (response && response.data && response.data.uuid && !response.data.markedAsSaved) {
                             $rootScope.draftData = response.data;
+                        }
+                        if ($rootScope.draftData && $rootScope.draftData.uuid && !$rootScope.draftData.markedAsSaved) {
                             $rootScope.resumeDraftOnLoad = true;
+                            $rootScope.resumeDraftPatientUuid = patientUuid;
                         }
                         concatObservationForms();
                     }, function () {
@@ -68,44 +72,56 @@ angular.module('bahmni.clinical')
                 $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');
                 $scope.allTemplates = $scope.allTemplates.concat($scope.consultation.observationForms);
 
-                if ($rootScope.resumeDraftOnLoad && $rootScope.draftData && $rootScope.draftData.formData) {
-                    var parsedDraftObs = angular.fromJson($rootScope.draftData.formData);
-                    if (parsedDraftObs && parsedDraftObs.length > 0) {
-                        var stripObservationFlags = function (obs) {
-                            if (!obs) { return obs; }
-                            var copy = angular.copy(obs);
-                            delete copy.isObservation;
-                            delete copy.isObservationNode;
-                            if (copy.groupMembers && copy.groupMembers.length > 0) {
-                                copy.groupMembers = _.map(copy.groupMembers, stripObservationFlags);
-                            }
-                            return copy;
-                        };
-                        _.each(parsedDraftObs, function (draftObs) {
-                            if (!draftObs.concept) { return; }
-                            var matchingTemplate = _.find($scope.allTemplates, function (t) {
-                                return t.uuid === draftObs.concept.uuid;
-                            });
-                            if (matchingTemplate && (!matchingTemplate.observations || matchingTemplate.observations.length === 0)) {
-                                matchingTemplate.observations = [stripObservationFlags(draftObs)];
-                            }
-                        });
-                        var form2DraftObs = _.filter(parsedDraftObs, function (draftObs) {
-                            return draftObs.formNamespace === 'Bahmni' && draftObs.formFieldPath;
-                        });
-                        if (form2DraftObs.length > 0) {
-                            _.each($scope.consultation.observationForms, function (obsForm) {
-                                var matchingObs = _.filter(form2DraftObs, function (draftObs) {
-                                    return draftObs.formFieldPath.split('.')[0] === obsForm.formName;
-                                });
-                                if (matchingObs.length > 0 && obsForm.observations.length === 0) {
-                                    _.each(matchingObs, function (obs) {
-                                        obsForm.observations.push(obs);
-                                    });
-                                    obsForm.isOpen = true;
-                                }
-                            });
+                var currentPatientUuid = $scope.patient ? $scope.patient.uuid : null;
+                var isDraftResumeValid = $rootScope.resumeDraftOnLoad &&
+                    $rootScope.draftData &&
+                    (!$rootScope.resumeDraftPatientUuid || $rootScope.resumeDraftPatientUuid === currentPatientUuid);
+                var draftFormData = isDraftResumeValid && $rootScope.draftData.formData ? $rootScope.draftData.formData : null;
+
+                var parsedDraftObs = null;
+                if (draftFormData) {
+                    try {
+                        parsedDraftObs = angular.fromJson(draftFormData);
+                    } catch (e) {
+                        parsedDraftObs = null;
+                    }
+                }
+
+                if (parsedDraftObs && parsedDraftObs.length > 0) {
+                    var stripObservationFlags = function (obs) {
+                        if (!obs) { return obs; }
+                        var copy = angular.copy(obs);
+                        delete copy.isObservation;
+                        delete copy.isObservationNode;
+                        if (copy.groupMembers && copy.groupMembers.length > 0) {
+                            copy.groupMembers = _.map(copy.groupMembers, stripObservationFlags);
                         }
+                        return copy;
+                    };
+                    _.each(parsedDraftObs, function (draftObs) {
+                        if (!draftObs.concept) { return; }
+                        var matchingTemplate = _.find($scope.allTemplates, function (t) {
+                            return t.uuid === draftObs.concept.uuid;
+                        });
+                        if (matchingTemplate && (!matchingTemplate.observations || matchingTemplate.observations.length === 0)) {
+                            matchingTemplate.observations = [stripObservationFlags(draftObs)];
+                        }
+                    });
+                    var form2DraftObs = _.filter(parsedDraftObs, function (draftObs) {
+                        return draftObs.formNamespace === 'Bahmni' && draftObs.formFieldPath;
+                    });
+                    if (form2DraftObs.length > 0) {
+                        _.each($scope.consultation.observationForms, function (obsForm) {
+                            var matchingObs = _.filter(form2DraftObs, function (draftObs) {
+                                return draftObs.formFieldPath.split('.')[0] === obsForm.formName;
+                            });
+                            if (matchingObs.length > 0 && obsForm.observations.length === 0) {
+                                _.each(matchingObs, function (obs) {
+                                    obsForm.observations.push(obs);
+                                });
+                                obsForm.isOpen = true;
+                            }
+                        });
                     }
                 }
 
@@ -114,7 +130,7 @@ angular.module('bahmni.clinical')
                     if ($scope.consultation.observations && $scope.consultation.observations.length > 0) {
                         addTemplatesInSavedOrder();
                     }
-                    if ($rootScope.resumeDraftOnLoad && $rootScope.draftData && $rootScope.draftData.formData) {
+                    if (draftFormData) {
                         _.each($scope.allTemplates, function (template) {
                             if (template.observations && template.observations.length > 0 &&
                                 !_.find($scope.consultation.selectedObsTemplate, function (t) { return t === template; })) {
@@ -129,9 +145,12 @@ angular.module('bahmni.clinical')
                         openTemplate(templateToBeOpened);
                     }
                 }
-                if ($rootScope.resumeDraftOnLoad && $rootScope.draftData && $rootScope.draftData.formData) {
-                    populateFormWithDraftData($rootScope.draftData.formData);
+                if (draftFormData) {
+                    populateFormWithDraftData(draftFormData);
+                }
+                if ($rootScope.resumeDraftOnLoad) {
                     $rootScope.resumeDraftOnLoad = false;
+                    $rootScope.resumeDraftPatientUuid = null;
                 }
                 $timeout(setupDirtyTracking, 0);
             };
@@ -487,6 +506,7 @@ angular.module('bahmni.clinical')
 
             $scope.saveAsDraft = saveFormDraft;
 
+            var draftCheckPromise = null;
             var draftContextWatchDeregister = null;
 
             var checkForExistingDrafts = function () {
@@ -504,7 +524,8 @@ angular.module('bahmni.clinical')
                     return true;
                 }
 
-                formDraftService.getDraft(patientUuid, providerUuid).then(
+                draftCheckPromise = formDraftService.getDraft(patientUuid, providerUuid);
+                draftCheckPromise.then(
                     function (response) {
                         if (response.data && response.data.uuid && !response.data.markedAsSaved) {
                             $scope.formDraft.hasDrafts = true;
@@ -518,18 +539,22 @@ angular.module('bahmni.clinical')
                                 $scope.formDraft.statusMessage = 'SAVED_AS_DRAFT_KEY';
                                 $scope.formDraft.statusParams = {draftDate: draftDate, draftTime: draftTime};
                             }
-                        } else {
+                        } else if (!$rootScope.resumeDraftOnLoad) {
                             $rootScope.draftData = null;
                             clearDraftStatus();
                         }
                     },
                     function () {
+                        if (!$rootScope.resumeDraftOnLoad) {
+                            $rootScope.draftData = null;
+                            clearDraftStatus();
+                        }
+                    }
+                ).catch(function () {
+                    if (!$rootScope.resumeDraftOnLoad) {
                         $rootScope.draftData = null;
                         clearDraftStatus();
                     }
-                ).catch(function () {
-                    $rootScope.draftData = null;
-                    clearDraftStatus();
                 });
 
                 return true;

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -49,10 +49,60 @@ angular.module('bahmni.clinical')
                 $scope.allTemplates = getSelectedObsTemplate(allConceptSections);
                 $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');
                 $scope.allTemplates = $scope.allTemplates.concat($scope.consultation.observationForms);
+
+                if ($rootScope.resumeDraftOnLoad && $rootScope.draftData && $rootScope.draftData.formData) {
+                    var parsedDraftObs = angular.fromJson($rootScope.draftData.formData);
+                    if (parsedDraftObs && parsedDraftObs.length > 0) {
+                        var stripObservationFlags = function (obs) {
+                            if (!obs) { return obs; }
+                            var copy = angular.copy(obs);
+                            delete copy.isObservation;
+                            delete copy.isObservationNode;
+                            if (copy.groupMembers && copy.groupMembers.length > 0) {
+                                copy.groupMembers = _.map(copy.groupMembers, stripObservationFlags);
+                            }
+                            return copy;
+                        };
+                        _.each(parsedDraftObs, function (draftObs) {
+                            if (!draftObs.concept) { return; }
+                            var matchingTemplate = _.find($scope.allTemplates, function (t) {
+                                return t.uuid === draftObs.concept.uuid;
+                            });
+                            if (matchingTemplate && (!matchingTemplate.observations || matchingTemplate.observations.length === 0)) {
+                                matchingTemplate.observations = [stripObservationFlags(draftObs)];
+                            }
+                        });
+                        var form2DraftObs = _.filter(parsedDraftObs, function (draftObs) {
+                            return draftObs.formNamespace === 'Bahmni' && draftObs.formFieldPath;
+                        });
+                        if (form2DraftObs.length > 0) {
+                            _.each($scope.consultation.observationForms, function (obsForm) {
+                                var matchingObs = _.filter(form2DraftObs, function (draftObs) {
+                                    return draftObs.formFieldPath.split('.')[0] === obsForm.formName;
+                                });
+                                if (matchingObs.length > 0 && obsForm.observations.length === 0) {
+                                    _.each(matchingObs, function (obs) {
+                                        obsForm.observations.push(obs);
+                                    });
+                                    obsForm.isOpen = true;
+                                }
+                            });
+                        }
+                    }
+                }
+
                 if ($scope.consultation.selectedObsTemplate.length == 0) {
                     initializeDefaultTemplates();
                     if ($scope.consultation.observations && $scope.consultation.observations.length > 0) {
                         addTemplatesInSavedOrder();
+                    }
+                    if ($rootScope.resumeDraftOnLoad && $rootScope.draftData && $rootScope.draftData.formData) {
+                        _.each($scope.allTemplates, function (template) {
+                            if (template.observations && template.observations.length > 0 &&
+                                !_.find($scope.consultation.selectedObsTemplate, function (t) { return t === template; })) {
+                                insertTemplate(template);
+                            }
+                        });
                     }
                     var templateToBeOpened = getLastVisitedTemplate() ||
                         _.first($scope.consultation.selectedObsTemplate);

--- a/ui/app/clinical/dashboard/controllers/patientDashboardController.js
+++ b/ui/app/clinical/dashboard/controllers/patientDashboardController.js
@@ -56,26 +56,8 @@ angular.module('bahmni.clinical')
                 if (!$scope.enableFormDraftFeature) {
                     return;
                 }
-
-                var patientUuid = $scope.patient ? $scope.patient.uuid : null;
-                var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
-
-                if (!patientUuid || !providerUuid) {
-                    return;
-                }
-
-                formDraftService.getDraft(patientUuid, providerUuid).then(function (response) {
-                    if (response.data && response.data.uuid && !response.data.markedAsSaved) {
-                        $rootScope.draftData = response.data;
-                        $rootScope.resumeDraftOnLoad = true;
-                        $rootScope.resumeDraftPatientUuid = patientUuid;
-                        $state.go('patient.dashboard.show.observations', {
-                            conceptSetGroupName: 'All Observation Templates'
-                        });
-                    }
-                }, function () {
-                    $scope.formDraft.statusMessage = 'RESUME_DRAFT_ERROR_KEY';
-                    $scope.formDraft.statusError = true;
+                $state.go('patient.dashboard.show.observations', {
+                    conceptSetGroupName: 'All Observation Templates'
                 });
             };
 

--- a/ui/app/clinical/dashboard/controllers/patientDashboardController.js
+++ b/ui/app/clinical/dashboard/controllers/patientDashboardController.js
@@ -53,6 +53,10 @@ angular.module('bahmni.clinical')
             };
 
             $scope.resumeDraft = function () {
+                if (!$scope.enableFormDraftFeature) {
+                    return;
+                }
+
                 var patientUuid = $scope.patient ? $scope.patient.uuid : null;
                 var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
 
@@ -64,10 +68,14 @@ angular.module('bahmni.clinical')
                     if (response.data && response.data.uuid && !response.data.markedAsSaved) {
                         $rootScope.draftData = response.data;
                         $rootScope.resumeDraftOnLoad = true;
+                        $rootScope.resumeDraftPatientUuid = patientUuid;
                         $state.go('patient.dashboard.show.observations', {
                             conceptSetGroupName: 'All Observation Templates'
                         });
                     }
+                }, function () {
+                    $scope.formDraft.statusMessage = 'RESUME_DRAFT_ERROR_KEY';
+                    $scope.formDraft.statusError = true;
                 });
             };
 

--- a/ui/app/clinical/dashboard/controllers/patientDashboardController.js
+++ b/ui/app/clinical/dashboard/controllers/patientDashboardController.js
@@ -53,20 +53,22 @@ angular.module('bahmni.clinical')
             };
 
             $scope.resumeDraft = function () {
-                // COMMENTED OUT: Resume draft functionality disabled
-                // // Set flag to auto-populate draft data in ConceptSetPageController
-                // $rootScope.resumeDraftOnLoad = true;
-                // // Navigate to last consultation tab if available, otherwise go to dashboard
-                // if ($scope.lastConsultationTabUrl && $scope.lastConsultationTabUrl.url) {
-                //     $location.url($scope.lastConsultationTabUrl.url);
-                // } else {
-                //     // Default to observations with all observation templates
-                //     $state.go('patient.dashboard.show.observations', {
-                //         patientUuid: $stateParams.patientUuid,
-                //         encounterUuid: $scope.consultation.encounterUuid,
-                //         conceptSetGroupName: 'All Observation Templates'
-                //     });
-                // }
+                var patientUuid = $scope.patient ? $scope.patient.uuid : null;
+                var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
+
+                if (!patientUuid || !providerUuid) {
+                    return;
+                }
+
+                formDraftService.getDraft(patientUuid, providerUuid).then(function (response) {
+                    if (response.data && response.data.uuid && !response.data.markedAsSaved) {
+                        $rootScope.draftData = response.data;
+                        $rootScope.resumeDraftOnLoad = true;
+                        $state.go('patient.dashboard.show.observations', {
+                            conceptSetGroupName: 'All Observation Templates'
+                        });
+                    }
+                });
             };
 
             var checkForExistingDrafts = function () {

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -1021,6 +1021,56 @@ describe('ConceptSetPageController', function () {
             expect(formDraftService.getDraft).not.toHaveBeenCalled();
         });
 
+        describe('Resume Draft', function () {
+            it('should populate form with draft data when resumeDraftOnLoad flag is set', function () {
+                var conceptUuid = 'concept-uuid-1';
+                var conceptResponseData = {
+                    results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]
+                };
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+
+                var timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+
+                var draftObs = {concept: {uuid: conceptUuid}, value: 'draft-value'};
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson([draftObs])};
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.resumeDraftOnLoad).toBe(false);
+            });
+
+            it('should not attempt population when resumeDraftOnLoad flag is not set', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+
+                var timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+
+                rootScope.resumeDraftOnLoad = false;
+                rootScope.draftData = null;
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.resumeDraftOnLoad).toBe(false);
+            });
+        });
+
         describe('Form2 Dirty Tracking', function () {
             var timeoutMock;
 

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -836,6 +836,32 @@ describe('ConceptSetPageController', function () {
             expect(scope.formDraft.statusError).toBe(false);
         });
 
+        it('should clear draft status when event:save-started is broadcast', function () {
+            var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
+            mockConceptSetService(conceptResponseData);
+            mockformService({});
+            createController();
+
+            scope.formDraft.isDirty = true;
+            scope.formDraft.hasDrafts = true;
+            scope.formDraft.draftDate = '08 Apr 2026';
+            scope.formDraft.draftTime = '10:30 AM';
+            scope.formDraft.statusMessage = 'SAVED_AS_DRAFT_KEY';
+            scope.formDraft.statusParams = {draftDate: '08 Apr 2026', draftTime: '10:30 AM'};
+            scope.formDraft.statusError = true;
+            scope.formDraft.showSpinner = true;
+
+            rootScope.$broadcast('event:save-started');
+
+            expect(scope.formDraft.showSpinner).toBe(false);
+            expect(scope.formDraft.hasDrafts).toBe(false);
+            expect(scope.formDraft.draftDate).toBeNull();
+            expect(scope.formDraft.draftTime).toBeNull();
+            expect(scope.formDraft.statusMessage).toBeNull();
+            expect(scope.formDraft.statusParams).toEqual({});
+            expect(scope.formDraft.statusError).toBe(false);
+        });
+
         it('should clear draft status and disable Save as Draft when consultation save succeeds', function () {
             var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
             mockConceptSetService(conceptResponseData);
@@ -1096,6 +1122,60 @@ describe('ConceptSetPageController', function () {
 
                 expect(rootScope.draftData).toBeNull();
             });
+
+            it('should not clobber draftData when resumeDraftOnLoad is set and getDraft promise catches unhandled error', function () {
+                scope.allTemplates = [{uuid: 'some-template', label: 'T', observations: [],
+                    isDefault: function () { return false; }, alwaysShow: false, isAvailable: function () { return true; }}];
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+                var existingDraftData = {uuid: 'draft-uuid', formData: '[]', markedAsSaved: false};
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = existingDraftData;
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function () {
+                        return {
+                            catch: function (handler) {
+                                handler();
+                                return this;
+                            }
+                        };
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.draftData).not.toBeNull();
+                expect(rootScope.draftData.uuid).toBe('draft-uuid');
+            });
+
+            it('should call checkForExistingDrafts when patient and provider become available after controller init', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: 'draft-uuid', markedAsSaved: false, timestamp: Date.now()}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                scope.patient = null;
+                rootScope.currentProvider = null;
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+                expect(formDraftService.getDraft).not.toHaveBeenCalled();
+
+                scope.patient = {uuid: 'late-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'late-provider-uuid'};
+                scope.$digest();
+
+                expect(formDraftService.getDraft).toHaveBeenCalledWith('late-patient-uuid', 'late-provider-uuid');
+                expect(scope.formDraft.hasDrafts).toBe(true);
+            });
         });
 
         describe('Resume Draft', function () {
@@ -1296,7 +1376,7 @@ describe('ConceptSetPageController', function () {
                 expect(obsForm.observations[0].formFieldPath).toBe('Fall Risk Assessment and Reassessment.3/10-0');
             });
 
-            it('should not call getDraft from loadDraftThenConcat when resumeDraftOnLoad is already set (Resume button path)', function () {
+            it('should not call getDraft from loadDraftThenConcat when resumeDraftOnLoad is already set', function () {
                 var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
                 mockConceptSetService(conceptResponseData);
                 mockformService({});
@@ -1483,6 +1563,24 @@ describe('ConceptSetPageController', function () {
 
                 var template = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
                 expect(template.observations.length).toBe(1);
+            });
+
+            it('should not throw and should not populate forms when formData is invalid JSON', function () {
+                var conceptUuid = 'concept-uuid-1';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: 'not-valid-json{{{'};
+
+                expect(function () {
+                    createControllerWithTimeoutAndFilter(timeoutMock);
+                }).not.toThrow();
+
+                var template = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(template.observations.length).toBe(0);
             });
 
             it('should skip draft obs that have no concept property', function () {

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -1071,6 +1071,328 @@ describe('ConceptSetPageController', function () {
             });
         });
 
+        describe('Auto-populate draft on direct navigation', function () {
+            var timeoutMock;
+
+            beforeEach(function () {
+                timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+            });
+
+            var enableDraftFeature = function () {
+                var appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
+                appDescriptor.getConfigValue.and.returnValue(true);
+                appService.getAppDescriptor.and.returnValue(appDescriptor);
+            };
+
+            // Both loadDraftThenConcat and checkForExistingDrafts call getDraft, so the mock
+            // must support .then(success, error).catch(fn) chaining on each invocation.
+            var mockDraftSuccess = function (draftData) {
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) {
+                        success({data: draftData});
+                        return {catch: function () { return this; }};
+                    }
+                });
+            };
+
+            var mockDraftError = function () {
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) {
+                        if (error) { error({status: 500}); }
+                        return {catch: function () { return this; }};
+                    }
+                });
+            };
+
+            it('should call getDraft when navigating directly to observations page with feature enabled', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(formDraftService.getDraft).toHaveBeenCalledWith('test-patient-uuid', 'test-provider-uuid');
+            });
+
+            it('should auto-populate concept-set forms when unsaved draft is found on direct navigation', function () {
+                var conceptUuid = 'concept-uuid-123';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'Orthopaedic Plan'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                var draftObs = [{concept: {uuid: conceptUuid, name: 'Orthopaedic Plan'}, isObservation: true, groupMembers: []}];
+                mockDraftSuccess({uuid: 'draft-uuid', markedAsSaved: false, formData: angular.toJson(draftObs)});
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var conceptSetTemplate = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(conceptSetTemplate.observations.length).toBe(1);
+            });
+
+            it('should auto-populate Form2 forms when unsaved draft is found on direct navigation', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var draftObs = [{
+                    concept: {uuid: 'age-uuid'}, value: 'val',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'
+                }];
+                mockDraftSuccess({uuid: 'draft-uuid', markedAsSaved: false, formData: angular.toJson(draftObs)});
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var obsForm = scope.consultation.observationForms[0];
+                expect(obsForm.observations.length).toBe(1);
+                expect(obsForm.observations[0].formFieldPath).toBe('Fall Risk Assessment and Reassessment.3/10-0');
+            });
+
+            it('should not call getDraft from loadDraftThenConcat when resumeDraftOnLoad is already set (Resume button path)', function () {
+                // checkForExistingDrafts still calls getDraft once; loadDraftThenConcat must not add a second call
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson([])};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(formDraftService.getDraft.calls.count()).toBe(1);
+            });
+
+            it('should not call getDraft from loadDraftThenConcat when enableFormDraftFeature is false', function () {
+                // checkForExistingDrafts still calls getDraft once; loadDraftThenConcat must not add a second call
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                // enableFormDraftFeature is false by default in beforeEach
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(formDraftService.getDraft.calls.count()).toBe(1);
+            });
+
+            it('should not call getDraft when patient uuid is missing', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = null;
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(formDraftService.getDraft).not.toHaveBeenCalled();
+            });
+
+            it('should not call getDraft when provider uuid is missing', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = null;
+                rootScope.resumeDraftOnLoad = false;
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(formDraftService.getDraft).not.toHaveBeenCalled();
+            });
+
+            it('should not populate forms when draft is marked as saved', function () {
+                var conceptUuid = 'concept-uuid-123';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'Orthopaedic Plan'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                var draftObs = [{concept: {uuid: conceptUuid}, isObservation: true, groupMembers: []}];
+                mockDraftSuccess({uuid: 'draft-uuid', markedAsSaved: true, formData: angular.toJson(draftObs)});
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var conceptSetTemplate = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(conceptSetTemplate.observations.length).toBe(0);
+                expect(rootScope.resumeDraftOnLoad).toBe(false);
+            });
+
+            it('should still load forms when getDraft call fails', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                mockDraftError();
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(scope.allTemplates).toBeDefined();
+                expect(scope.allTemplates.length).toBeGreaterThan(0);
+            });
+
+            it('should set resumeDraftOnLoad to false after auto-population on direct navigation', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                var draftObs = [{concept: {uuid: 'concept-uuid-1'}, isObservation: true, groupMembers: []}];
+                mockDraftSuccess({uuid: 'draft-uuid', markedAsSaved: false, formData: angular.toJson(draftObs)});
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.resumeDraftOnLoad).toBe(false);
+            });
+        });
+
+        describe('loadDraftThenConcat edge cases', function () {
+            var timeoutMock;
+
+            beforeEach(function () {
+                timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+            });
+
+            var enableDraftFeature = function () {
+                var appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
+                appDescriptor.getConfigValue.and.returnValue(true);
+                appService.getAppDescriptor.and.returnValue(appDescriptor);
+            };
+
+            it('should call loadDraftThenConcat via the else branch when observationForms is already populated', function () {
+                // Covers the else branch at line 43 (observationForms pre-set, getFormList not called)
+                var conceptUuid = 'concept-uuid-1';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                // Pre-populate observationForms so the else branch is taken
+                scope.consultation.observationForms = [{
+                    formName: 'Pre-loaded Form', formUuid: 'pre-loaded-uuid', formVersion: '1',
+                    label: 'Pre-loaded Form', conceptName: 'Pre-loaded Form',
+                    observations: [], isDefault: function () { return false; }, alwaysShow: false,
+                    isAvailable: function () { return true; }
+                }];
+
+                var draftObs = [{concept: {uuid: conceptUuid, name: 'abcd'}, isObservation: true, groupMembers: []}];
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) {
+                        success({data: {uuid: 'draft-uuid', markedAsSaved: false, formData: angular.toJson(draftObs)}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                // formService.getFormList should NOT have been called (else branch skips it)
+                expect(formService.getFormList).not.toHaveBeenCalled();
+                // getDraft was still called by loadDraftThenConcat and checkForExistingDrafts
+                expect(formDraftService.getDraft).toHaveBeenCalledWith('test-patient-uuid', 'test-provider-uuid');
+            });
+
+            it('should handle null groupMember inside stripObservationFlags without throwing', function () {
+                // Covers the null-guard at line 75 inside stripObservationFlags
+                var conceptUuid = 'concept-uuid-1';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                // Draft obs with a null entry in groupMembers
+                var draftObs = [{
+                    concept: {uuid: conceptUuid}, isObservation: true,
+                    groupMembers: [null, {concept: {uuid: 'child-uuid'}, value: 'v', isObservation: true}]
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(draftObs)};
+
+                expect(function () {
+                    createControllerWithTimeoutAndFilter(timeoutMock);
+                }).not.toThrow();
+
+                var template = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(template.observations.length).toBe(1);
+            });
+
+            it('should skip draft obs that have no concept property', function () {
+                // Covers the early-return at line 85 inside the _.each loop
+                var conceptUuid = 'concept-uuid-1';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                // Mix: one valid obs, one without concept
+                var draftObs = [
+                    {isObservation: true, value: 'orphan', groupMembers: []},
+                    {concept: {uuid: conceptUuid, name: 'abcd'}, isObservation: true, groupMembers: []}
+                ];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(draftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var template = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(template.observations.length).toBe(1);
+            });
+        });
+
         describe('Resume Draft - Form2 Observations', function () {
             var timeoutMock;
 

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -70,7 +70,6 @@ describe('ConceptSetPageController', function () {
         appDescriptor.getConfigValue.and.returnValue(false);
         appService.getAppDescriptor.and.returnValue(appDescriptor);
         formDraftService = jasmine.createSpyObj('formDraftService', ['saveDraft', 'getDraft']);
-        // Configure getDraft to return a rejected promise by default (no existing draft)
         formDraftService.getDraft.and.returnValue({
             then: function (success, error) {
                 if (error) error();
@@ -748,7 +747,6 @@ describe('ConceptSetPageController', function () {
             createControllerWithTimeoutAndFilter();
             scope.saveAsDraft();
 
-            // The controller uses .then(successFn, errorFn) - trigger the error via the second argument
             var thenArgs = saveDraftPromise.then.calls.mostRecent().args;
             thenArgs[1]({status: 500, data: {error: {message: 'Server error'}}});
 
@@ -808,7 +806,6 @@ describe('ConceptSetPageController', function () {
             var postSaveHandler = scope.consultation.postSaveHandler;
             expect(postSaveHandler).toBeDefined();
 
-            // Execute the post-save handler
             postSaveHandler.fire();
 
             expect(scope.formDraft.isDirty).toBe(false);
@@ -1021,6 +1018,86 @@ describe('ConceptSetPageController', function () {
             expect(formDraftService.getDraft).not.toHaveBeenCalled();
         });
 
+        describe('checkForExistingDrafts — resume race condition guard', function () {
+            var timeoutMock;
+
+            beforeEach(function () {
+                timeoutMock = function (callback, delay) {
+                    if (delay === 0 || delay === 500) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+            });
+
+            it('should not clobber draftData when resumeDraftOnLoad is set and getDraft returns no valid draft', function () {
+                scope.allTemplates = [{uuid: 'some-template', label: 'T', observations: [],
+                    isDefault: function () { return false; }, alwaysShow: false, isAvailable: function () { return true; }}];
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+                var existingDraftData = {uuid: 'draft-uuid', formData: '[]', markedAsSaved: false};
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = existingDraftData;
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) {
+                        success({data: {uuid: null}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.draftData).not.toBeNull();
+                expect(rootScope.draftData.uuid).toBe('draft-uuid');
+            });
+
+            it('should not clobber draftData when resumeDraftOnLoad is set and getDraft errors', function () {
+                scope.allTemplates = [{uuid: 'some-template', label: 'T', observations: [],
+                    isDefault: function () { return false; }, alwaysShow: false, isAvailable: function () { return true; }}];
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+                var existingDraftData = {uuid: 'draft-uuid', formData: '[]', markedAsSaved: false};
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = existingDraftData;
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) {
+                        error({status: 500});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.draftData).not.toBeNull();
+                expect(rootScope.draftData.uuid).toBe('draft-uuid');
+            });
+
+            it('should still null draftData when resumeDraftOnLoad is false and getDraft returns no valid draft', function () {
+                scope.allTemplates = [{uuid: 'some-template', label: 'T', observations: [],
+                    isDefault: function () { return false; }, alwaysShow: false, isAvailable: function () { return true; }}];
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) {
+                        success({data: {uuid: null}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.draftData).toBeNull();
+            });
+        });
+
         describe('Resume Draft', function () {
             it('should populate form with draft data when resumeDraftOnLoad flag is set', function () {
                 var conceptUuid = 'concept-uuid-1';
@@ -1069,6 +1146,55 @@ describe('ConceptSetPageController', function () {
 
                 expect(rootScope.resumeDraftOnLoad).toBe(false);
             });
+
+            it('should always clear resumeDraftOnLoad even when formData is absent', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+
+                var timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {uuid: 'draft-uuid', formData: null};
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.resumeDraftOnLoad).toBe(false);
+            });
+
+            it('should not populate forms from a different patient when resumeDraftPatientUuid does not match', function () {
+                var conceptUuid = 'concept-uuid-1';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+
+                var draftObs = [{concept: {uuid: conceptUuid}, isObservation: true, groupMembers: []}];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.resumeDraftPatientUuid = 'other-patient-uuid';
+                rootScope.draftData = {formData: angular.toJson(draftObs)};
+                scope.patient = {uuid: 'current-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var template = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(template.observations.length).toBe(0);
+                expect(rootScope.resumeDraftOnLoad).toBe(false);
+                expect(rootScope.resumeDraftPatientUuid).toBeNull();
+            });
         });
 
         describe('Auto-populate draft on direct navigation', function () {
@@ -1088,8 +1214,6 @@ describe('ConceptSetPageController', function () {
                 appService.getAppDescriptor.and.returnValue(appDescriptor);
             };
 
-            // Both loadDraftThenConcat and checkForExistingDrafts call getDraft, so the mock
-            // must support .then(success, error).catch(fn) chaining on each invocation.
             var mockDraftSuccess = function (draftData) {
                 formDraftService.getDraft.and.returnValue({
                     then: function (success, error) {
@@ -1173,7 +1297,6 @@ describe('ConceptSetPageController', function () {
             });
 
             it('should not call getDraft from loadDraftThenConcat when resumeDraftOnLoad is already set (Resume button path)', function () {
-                // checkForExistingDrafts still calls getDraft once; loadDraftThenConcat must not add a second call
                 var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
                 mockConceptSetService(conceptResponseData);
                 mockformService({});
@@ -1190,11 +1313,9 @@ describe('ConceptSetPageController', function () {
             });
 
             it('should not call getDraft from loadDraftThenConcat when enableFormDraftFeature is false', function () {
-                // checkForExistingDrafts still calls getDraft once; loadDraftThenConcat must not add a second call
                 var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
                 mockConceptSetService(conceptResponseData);
                 mockformService({});
-                // enableFormDraftFeature is false by default in beforeEach
 
                 scope.patient = {uuid: 'test-patient-uuid'};
                 rootScope.currentProvider = {uuid: 'test-provider-uuid'};
@@ -1311,7 +1432,6 @@ describe('ConceptSetPageController', function () {
             };
 
             it('should call loadDraftThenConcat via the else branch when observationForms is already populated', function () {
-                // Covers the else branch at line 43 (observationForms pre-set, getFormList not called)
                 var conceptUuid = 'concept-uuid-1';
                 var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
                 mockConceptSetService(conceptResponseData);
@@ -1322,7 +1442,6 @@ describe('ConceptSetPageController', function () {
                 rootScope.resumeDraftOnLoad = false;
                 rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
 
-                // Pre-populate observationForms so the else branch is taken
                 scope.consultation.observationForms = [{
                     formName: 'Pre-loaded Form', formUuid: 'pre-loaded-uuid', formVersion: '1',
                     label: 'Pre-loaded Form', conceptName: 'Pre-loaded Form',
@@ -1340,21 +1459,17 @@ describe('ConceptSetPageController', function () {
 
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
-                // formService.getFormList should NOT have been called (else branch skips it)
                 expect(formService.getFormList).not.toHaveBeenCalled();
-                // getDraft was still called by loadDraftThenConcat and checkForExistingDrafts
                 expect(formDraftService.getDraft).toHaveBeenCalledWith('test-patient-uuid', 'test-provider-uuid');
             });
 
             it('should handle null groupMember inside stripObservationFlags without throwing', function () {
-                // Covers the null-guard at line 75 inside stripObservationFlags
                 var conceptUuid = 'concept-uuid-1';
                 var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
                 mockConceptSetService(conceptResponseData);
                 mockformService({});
                 rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
 
-                // Draft obs with a null entry in groupMembers
                 var draftObs = [{
                     concept: {uuid: conceptUuid}, isObservation: true,
                     groupMembers: [null, {concept: {uuid: 'child-uuid'}, value: 'v', isObservation: true}]
@@ -1371,14 +1486,12 @@ describe('ConceptSetPageController', function () {
             });
 
             it('should skip draft obs that have no concept property', function () {
-                // Covers the early-return at line 85 inside the _.each loop
                 var conceptUuid = 'concept-uuid-1';
                 var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: conceptUuid}]}]};
                 mockConceptSetService(conceptResponseData);
                 mockformService({});
                 rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
 
-                // Mix: one valid obs, one without concept
                 var draftObs = [
                     {isObservation: true, value: 'orphan', groupMembers: []},
                     {concept: {uuid: conceptUuid, name: 'abcd'}, isObservation: true, groupMembers: []}
@@ -1767,7 +1880,6 @@ describe('ConceptSetPageController', function () {
 
                 scope.$digest();
 
-                // Destroy the scope
                 scope.$destroy();
                 expect(removeEventListenerSpy).toHaveBeenCalledWith('input', jasmine.any(Function), true);
                 expect(removeEventListenerSpy).toHaveBeenCalledWith('change', jasmine.any(Function), true);

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -1071,6 +1071,256 @@ describe('ConceptSetPageController', function () {
             });
         });
 
+        describe('Resume Draft - Form2 Observations', function () {
+            var timeoutMock;
+
+            beforeEach(function () {
+                timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+            });
+
+            it('should inject Form2 draft observations into matching ObservationForm by formFieldPath', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var form2DraftObs = [
+                    {concept: {uuid: 'age-uuid', name: 'Fall Risk Age'}, value: {uuid: 'ans-uuid'}, formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'},
+                    {concept: {uuid: 'score-uuid', name: 'Fall Risk Score'}, value: 5, formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/11-0'}
+                ];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(form2DraftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var obsForm = scope.consultation.observationForms[0];
+                expect(obsForm.observations.length).toBe(2);
+                expect(obsForm.observations[0].formFieldPath).toBe('Fall Risk Assessment and Reassessment.3/10-0');
+                expect(obsForm.observations[1].formFieldPath).toBe('Fall Risk Assessment and Reassessment.3/11-0');
+            });
+
+            it('should set ObservationForm isOpen to true when Form2 draft observations are injected', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var form2DraftObs = [{
+                    concept: {uuid: 'age-uuid'}, value: {uuid: 'ans-uuid'},
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(form2DraftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(scope.consultation.observationForms[0].isOpen).toBe(true);
+            });
+
+            it('should add Form2 form to selectedObsTemplate when it has draft observations', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var form2DraftObs = [{
+                    concept: {uuid: 'age-uuid'}, value: 'val',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(form2DraftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var addedForm = _.find(scope.consultation.selectedObsTemplate, function (t) {
+                    return t.formName === 'Fall Risk Assessment and Reassessment';
+                });
+                expect(addedForm).toBeDefined();
+            });
+
+            it('should not overwrite existing ObservationForm observations with draft obs when form already has observations', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var existingObs = {
+                    concept: {uuid: 'existing-uuid'}, value: 'existing-value',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'
+                };
+                scope.patient = {uuid: 'test-patient-uuid'};
+                scope.consultation.observations = [existingObs];
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var form2DraftObs = [{
+                    concept: {uuid: 'draft-uuid'}, value: 'draft-value',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/20-0'
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(form2DraftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var obsForm = scope.consultation.observationForms[0];
+                expect(obsForm.observations.length).toBe(1);
+                expect(obsForm.observations[0].concept.uuid).toBe('existing-uuid');
+            });
+
+            it('should not inject Form2 obs when no ObservationForm name matches the formFieldPath', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var form2Data = [{
+                    name: 'Different Form', uuid: 'different-form-uuid', version: '1',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var form2DraftObs = [{
+                    concept: {uuid: 'uuid1'}, value: 'val',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(form2DraftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(scope.consultation.observationForms[0].observations.length).toBe(0);
+            });
+
+            it('should correctly handle mix of concept-set and Form2 draft observations', function () {
+                var conceptUuid = 'concept-uuid-123';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'Orthopaedic Plan'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var draftObs = [
+                    {concept: {uuid: conceptUuid, name: 'Orthopaedic Plan'}, isObservation: true, groupMembers: []},
+                    {concept: {uuid: 'age-uuid', name: 'Fall Risk Age'}, value: {uuid: 'ans-uuid'}, formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'}
+                ];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(draftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var conceptSetTemplate = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(conceptSetTemplate.observations.length).toBe(1);
+
+                expect(scope.consultation.observationForms[0].observations.length).toBe(1);
+                expect(scope.consultation.observationForms[0].observations[0].formFieldPath).toBe('Fall Risk Assessment and Reassessment.3/10-0');
+            });
+
+            it('should strip isObservation and isObservationNode flags recursively from concept-set draft obs', function () {
+                var conceptUuid = 'concept-uuid-123';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'Orthopaedic Plan'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var draftObs = [{
+                    concept: {uuid: conceptUuid},
+                    isObservation: true,
+                    isObservationNode: true,
+                    groupMembers: [{concept: {uuid: 'child-uuid'}, value: 'child-value', isObservation: true}]
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(draftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var conceptSetTemplate = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(conceptSetTemplate.observations.length).toBe(1);
+                var injected = conceptSetTemplate.observations[0];
+                expect(injected.isObservation).toBeUndefined();
+                expect(injected.isObservationNode).toBeUndefined();
+                expect(injected.groupMembers[0].isObservation).toBeUndefined();
+            });
+
+            it('should not add duplicate Form2 form to selectedObsTemplate when it is a favourite', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                rootScope.currentUser = {
+                    isFavouriteObsTemplate: function (name) {
+                        return name === 'Fall Risk Assessment and Reassessment';
+                    }
+                };
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+
+                var form2DraftObs = [{
+                    concept: {uuid: 'age-uuid'}, value: 'val',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(form2DraftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var matchingTemplates = _.filter(scope.consultation.selectedObsTemplate, function (t) {
+                    return t.formName === 'Fall Risk Assessment and Reassessment';
+                });
+                expect(matchingTemplates.length).toBe(1);
+            });
+
+            it('should clear resumeDraftOnLoad flag after processing Form2 draft observations', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'concept-uuid-1'}]}]};
+                mockConceptSetService(conceptResponseData);
+
+                var form2Data = [{
+                    name: 'Fall Risk Assessment and Reassessment', uuid: 'fall-risk-form-uuid', version: '3',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var form2DraftObs = [{
+                    concept: {uuid: 'age-uuid'}, value: 'val',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment and Reassessment.3/10-0'
+                }];
+                rootScope.resumeDraftOnLoad = true;
+                rootScope.draftData = {formData: angular.toJson(form2DraftObs)};
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.resumeDraftOnLoad).toBe(false);
+            });
+        });
+
         describe('Form2 Dirty Tracking', function () {
             var timeoutMock;
 

--- a/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
+++ b/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
@@ -421,92 +421,27 @@ describe("patient dashboard controller", function () {
 
         describe("resumeDraft", function () {
             beforeEach(function () {
-                _appConfig.getConfigValue.and.returnValue(true);
-            });
-
-            it("should make GET call, set resumeDraftOnLoad flag and navigate to observations page", function () {
                 _state.go = jasmine.createSpy('go');
                 _formDraftService.getDraft.and.returnValue({
-                    then: function (success) {
-                        success({data: {uuid: 'draft-uuid', formData: '[]', markedAsSaved: false}});
-                        return this;
-                    },
+                    then: function () { return this; },
                     catch: function () { return this; }
                 });
+            });
 
+            it("should navigate to observations page when feature is enabled", function () {
+                _appConfig.getConfigValue.and.returnValue(true);
                 createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
                 scope.resumeDraft();
 
-                expect(_formDraftService.getDraft).toHaveBeenCalledWith('patient-uuid', 'provider-uuid');
-                expect(_rootScope.resumeDraftOnLoad).toBe(true);
-                expect(_rootScope.draftData.uuid).toBe('draft-uuid');
                 expect(_state.go).toHaveBeenCalledWith('patient.dashboard.show.observations', {
                     conceptSetGroupName: 'All Observation Templates'
                 });
             });
 
-            it("should not navigate when patient uuid is missing", function () {
-                _state.go = jasmine.createSpy('go');
-                createControllerForDraft(null, {uuid: 'provider-uuid'});
-                scope.resumeDraft();
-                expect(_state.go).not.toHaveBeenCalled();
-            });
-
-            it("should not navigate when provider uuid is missing", function () {
-                _state.go = jasmine.createSpy('go');
-                createControllerForDraft({uuid: 'patient-uuid'}, null);
-                scope.resumeDraft();
-                expect(_state.go).not.toHaveBeenCalled();
-            });
-
-            it("should not navigate when draft is already marked as saved", function () {
-                _state.go = jasmine.createSpy('go');
-                _formDraftService.getDraft.and.returnValue({
-                    then: function (success) {
-                        success({data: {uuid: 'draft-uuid', markedAsSaved: true}});
-                        return this;
-                    },
-                    catch: function () { return this; }
-                });
-
-                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
-                scope.resumeDraft();
-
-                expect(_state.go).not.toHaveBeenCalled();
-            });
-
-            it("should set statusError when getDraft fails during resumeDraft", function () {
-                _state.go = jasmine.createSpy('go');
-                _formDraftService.getDraft.and.returnValue({
-                    then: function (success, error) {
-                        error({status: 500});
-                        return this;
-                    },
-                    catch: function () { return this; }
-                });
-
-                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
-                scope.resumeDraft();
-
-                expect(_state.go).not.toHaveBeenCalled();
-                expect(scope.formDraft.statusError).toBe(true);
-                expect(scope.formDraft.statusMessage).toBe('RESUME_DRAFT_ERROR_KEY');
-            });
-
-            it("should not call getDraft or navigate when enableFormDraftFeature is false", function () {
-                _state.go = jasmine.createSpy('go');
+            it("should not navigate when enableFormDraftFeature is false", function () {
                 _appConfig.getConfigValue.and.returnValue(false);
-                _formDraftService.getDraft.and.returnValue({
-                    then: function (success, error) { if (error) { error(); } return this; },
-                    catch: function () { return this; }
-                });
-
                 createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
-                _formDraftService.getDraft.calls.reset();
-
                 scope.resumeDraft();
-
-                expect(_formDraftService.getDraft).not.toHaveBeenCalled();
                 expect(_state.go).not.toHaveBeenCalled();
             });
         });

--- a/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
+++ b/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
@@ -419,6 +419,59 @@ describe("patient dashboard controller", function () {
             expect(scope.formDraft.draftTime).toBeNull();
         });
 
+        describe("resumeDraft", function () {
+            it("should make GET call, set resumeDraftOnLoad flag and navigate to observations page", function () {
+                _state.go = jasmine.createSpy('go');
+                _formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: 'draft-uuid', formData: '[]', markedAsSaved: false}});
+                        return this;
+                    },
+                    catch: function () { return this; }
+                });
+
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.resumeDraft();
+
+                expect(_formDraftService.getDraft).toHaveBeenCalledWith('patient-uuid', 'provider-uuid');
+                expect(_rootScope.resumeDraftOnLoad).toBe(true);
+                expect(_rootScope.draftData.uuid).toBe('draft-uuid');
+                expect(_state.go).toHaveBeenCalledWith('patient.dashboard.show.observations', {
+                    conceptSetGroupName: 'All Observation Templates'
+                });
+            });
+
+            it("should not navigate when patient uuid is missing", function () {
+                _state.go = jasmine.createSpy('go');
+                createControllerForDraft(null, {uuid: 'provider-uuid'});
+                scope.resumeDraft();
+                expect(_state.go).not.toHaveBeenCalled();
+            });
+
+            it("should not navigate when provider uuid is missing", function () {
+                _state.go = jasmine.createSpy('go');
+                createControllerForDraft({uuid: 'patient-uuid'}, null);
+                scope.resumeDraft();
+                expect(_state.go).not.toHaveBeenCalled();
+            });
+
+            it("should not navigate when draft is already marked as saved", function () {
+                _state.go = jasmine.createSpy('go');
+                _formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: 'draft-uuid', markedAsSaved: true}});
+                        return this;
+                    },
+                    catch: function () { return this; }
+                });
+
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.resumeDraft();
+
+                expect(_state.go).not.toHaveBeenCalled();
+            });
+        });
+
         it("should use dashboard-content templateUrl when dashboard-content view is configured", function () {
             _state.current.views['dashboard-content'] = {
                 templateUrl: 'dashboard/views/custom-content.html'

--- a/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
+++ b/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
@@ -420,6 +420,10 @@ describe("patient dashboard controller", function () {
         });
 
         describe("resumeDraft", function () {
+            beforeEach(function () {
+                _appConfig.getConfigValue.and.returnValue(true);
+            });
+
             it("should make GET call, set resumeDraftOnLoad flag and navigate to observations page", function () {
                 _state.go = jasmine.createSpy('go');
                 _formDraftService.getDraft.and.returnValue({
@@ -468,6 +472,41 @@ describe("patient dashboard controller", function () {
                 createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
                 scope.resumeDraft();
 
+                expect(_state.go).not.toHaveBeenCalled();
+            });
+
+            it("should set statusError when getDraft fails during resumeDraft", function () {
+                _state.go = jasmine.createSpy('go');
+                _formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) {
+                        error({status: 500});
+                        return this;
+                    },
+                    catch: function () { return this; }
+                });
+
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.resumeDraft();
+
+                expect(_state.go).not.toHaveBeenCalled();
+                expect(scope.formDraft.statusError).toBe(true);
+                expect(scope.formDraft.statusMessage).toBe('RESUME_DRAFT_ERROR_KEY');
+            });
+
+            it("should not call getDraft or navigate when enableFormDraftFeature is false", function () {
+                _state.go = jasmine.createSpy('go');
+                _appConfig.getConfigValue.and.returnValue(false);
+                _formDraftService.getDraft.and.returnValue({
+                    then: function (success, error) { if (error) { error(); } return this; },
+                    catch: function () { return this; }
+                });
+
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                _formDraftService.getDraft.calls.reset();
+
+                scope.resumeDraft();
+
+                expect(_formDraftService.getDraft).not.toHaveBeenCalled();
                 expect(_state.go).not.toHaveBeenCalled();
             });
         });


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionViewId=aLgrTmXYc4HRqLbXw&projectId=sfxBCpc3JKca3H2S8&tabId=thBjsTJW9AaHvQQBr&activeTab=&actionId=oGrcaYuWCRv7fYm94

PR Review issues identified and fixed by Claude Plugin:
1. `$rootScope.resumeDraftOnLoad` never cleared when `formData` is absent
2. Cross-patient state leak — `resumeDraftOnLoad` and `draftData` persist if user navigates away mid-flight
3. No try/catch around `angular.fromJson` in `concatObservationForms`
4. No error handler on `getDraft` in `resumeDraft` — silent failure on network error
5. Two `getDraft` network calls fired on every direct navigation to Consultation
6. `resumeDraft()` not gated on `enableFormDraftFeature`
7. Race condition — `checkForExistingDrafts` can clobber `draftData` during the Resume button path
8. Missing test for `resumeDraft` network-error path
9. Triple guard pattern — `resumeDraftOnLoad` condition evaluated 3 times; duplicate parse site
