### PR TITLE
Bindu | HIV-71723 | fix the cancel suregry issue on calendar view

### DIFF
--- a/ui/app/ot/controller/calendarViewCancelAppointmentController.js
+++ b/ui/app/ot/controller/calendarViewCancelAppointmentController.js
@@ -56,12 +56,14 @@ angular.module('bahmni.ot').controller('calendarViewCancelAppointmentController'
                     return !_.isUndefined(attribute.value);
                 }).map(function (attribute) {
                     if (attribute.surgicalAppointmentAttributeType && attribute.surgicalAppointmentAttributeType.name === 'otherSurgeon') {
-                        attribute.value = attribute.value && attribute.value.id;
+                        if (attribute.value && typeof attribute.value === 'object') {
+                            attribute.value = attribute.value.id;
+                        }
                     }
-                    attribute.value = !_.isNull(attribute.value) && attribute.value.toString() || "";
+                    attribute.value = (attribute.value != null) ? attribute.value.toString() : "";
                     return attribute;
                 });
-                return _.omit(appointment, ['derivedAttributes', 'surgicalBlock', 'bedNumber', 'bedLocation', 'primaryDiagnosis', 'observationMap']);
+                return _.omit(appointment, ['derivedAttributes', 'surgicalBlock', 'bedNumber', 'bedLocation', 'primaryDiagnosis', 'observationMap', 'patientObservations']);
             });
 
             return surgicalAppointmentService.updateSurgicalBlock(surgicalBlock);


### PR DESCRIPTION
**Issue details:**
  1. **OtherSurgeon attribute handling:** Only extract .id when the value is an object. In the calendar view, raw API data has otherSurgeon.value as a string already — the old code would set it
   to undefined and crash on .toString().                                                                                                                                                                  
  2. **Added patientObservations to omit list (line 66)**: The calendar view's otCalendarSurgicalBlock directive keeps patientObservations on appointments (used for primaryDiagnosis display). This property  
  was being sent to the API in the updateSurgicalBlock call, causing the ConversionException because the server can't deserialize it back. The moveSurgicalAppointmentController already omits this property — now the cancel controller does too. 
     
HIVE Card -  https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=EzZJxK56LPTJAd3iW