### PR TITLE
Pooja | Feature 113099 discard draft: Discard Draft using banner UI

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -21,6 +21,12 @@ angular.module('bahmni.clinical')
             var allConceptSections = [];
 
             var init = function () {
+                if ($rootScope.draftDiscarded) {
+                    $scope.allTemplates = [];
+                    $scope.consultation.selectedObsTemplate = [];
+                    $scope.consultation.observationForms = [];
+                    $rootScope.draftDiscarded = false;
+                }
                 if (!($scope.allTemplates !== undefined && $scope.allTemplates.length > 0)) {
                     spinner.forPromise(conceptSetService.getConcept({
                         name: "All Observation Templates",
@@ -49,10 +55,12 @@ angular.module('bahmni.clinical')
                 var patientUuid = $scope.patient ? $scope.patient.uuid : null;
                 var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
                 if ($scope.enableFormDraftFeature && !$rootScope.resumeDraftOnLoad && patientUuid && providerUuid) {
-                    var promise = draftCheckPromise || formDraftService.getDraft(patientUuid, providerUuid);
+                    var promise = formDraftService.getDraft(patientUuid, providerUuid);
                     promise.then(function (response) {
                         if (response && response.data && response.data.uuid && !response.data.markedAsSaved) {
                             $rootScope.draftData = response.data;
+                        } else {
+                            $rootScope.draftData = null;
                         }
                         if ($rootScope.draftData && $rootScope.draftData.uuid && !$rootScope.draftData.markedAsSaved) {
                             $rootScope.resumeDraftOnLoad = true;

--- a/ui/app/clinical/dashboard/controllers/patientDashboardController.js
+++ b/ui/app/clinical/dashboard/controllers/patientDashboardController.js
@@ -2,9 +2,9 @@
 
 angular.module('bahmni.clinical')
     .controller('PatientDashboardController', ['$scope', 'clinicalAppConfigService', 'clinicalDashboardConfig', 'printer',
-        '$state', 'spinner', 'visitSummary', 'appService', '$stateParams', 'diseaseTemplateService', 'patientContext', '$location', '$filter', 'formDraftService', '$rootScope', 'ngDialog',
+        '$state', 'spinner', 'visitSummary', 'appService', '$stateParams', 'diseaseTemplateService', 'patientContext', '$location', '$filter', 'formDraftService', '$rootScope', 'ngDialog', '$timeout',
         function ($scope, clinicalAppConfigService, clinicalDashboardConfig, printer,
-            $state, spinner, visitSummary, appService, $stateParams, diseaseTemplateService, patientContext, $location, $filter, formDraftService, $rootScope, ngDialog) {
+            $state, spinner, visitSummary, appService, $stateParams, diseaseTemplateService, patientContext, $location, $filter, formDraftService, $rootScope, ngDialog, $timeout) {
             $scope.enableFormDraftFeature = appService.getAppDescriptor().getConfigValue('enableFormDraftFeature');
             $scope.patient = patientContext.patient;
             $scope.activeVisit = $scope.visitHistory.activeVisit;
@@ -26,7 +26,8 @@ angular.module('bahmni.clinical')
             $scope.formDraft = {
                 draftDate: draftTimestampObj.date,
                 draftTime: draftTimestampObj.time,
-                hasDrafts: false
+                hasDrafts: false,
+                discardSuccess: false
             };
             var programConfig = appService.getAppDescriptor().getConfigValue("program") || {};
             $state.discardChanges = false;
@@ -78,11 +79,18 @@ angular.module('bahmni.clinical')
                         $scope.formDraft.hasDrafts = false;
                         $scope.formDraft.draftDate = null;
                         $scope.formDraft.draftTime = null;
+                        $scope.formDraft.discardSuccess = true;
                         $rootScope.draftData = null;
                         $rootScope.resumeDraftOnLoad = false;
                         $rootScope.resumeDraftPatientUuid = null;
+                        $rootScope.hasVisitedConsultation = false;
+                        $state.discardChanges = true;
+                        $state.dirtyConsultationForm = false;
                         $rootScope.draftDiscarded = true;
                         ngDialog.close(dialog.id);
+                        $timeout(function () {
+                            $scope.formDraft.discardSuccess = false;
+                        }, 5000);
                     });
                 };
             };

--- a/ui/app/clinical/dashboard/controllers/patientDashboardController.js
+++ b/ui/app/clinical/dashboard/controllers/patientDashboardController.js
@@ -2,9 +2,9 @@
 
 angular.module('bahmni.clinical')
     .controller('PatientDashboardController', ['$scope', 'clinicalAppConfigService', 'clinicalDashboardConfig', 'printer',
-        '$state', 'spinner', 'visitSummary', 'appService', '$stateParams', 'diseaseTemplateService', 'patientContext', '$location', '$filter', 'formDraftService', '$rootScope',
+        '$state', 'spinner', 'visitSummary', 'appService', '$stateParams', 'diseaseTemplateService', 'patientContext', '$location', '$filter', 'formDraftService', '$rootScope', 'ngDialog',
         function ($scope, clinicalAppConfigService, clinicalDashboardConfig, printer,
-            $state, spinner, visitSummary, appService, $stateParams, diseaseTemplateService, patientContext, $location, $filter, formDraftService, $rootScope) {
+            $state, spinner, visitSummary, appService, $stateParams, diseaseTemplateService, patientContext, $location, $filter, formDraftService, $rootScope, ngDialog) {
             $scope.enableFormDraftFeature = appService.getAppDescriptor().getConfigValue('enableFormDraftFeature');
             $scope.patient = patientContext.patient;
             $scope.activeVisit = $scope.visitHistory.activeVisit;
@@ -59,6 +59,32 @@ angular.module('bahmni.clinical')
                 $state.go('patient.dashboard.show.observations', {
                     conceptSetGroupName: 'All Observation Templates'
                 });
+            };
+
+            $scope.confirmDiscardDraft = function () {
+                var dialogScope = $scope.$new();
+                var dialog = ngDialog.open({
+                    template: 'dashboard/views/discardDraftConfirmation.html',
+                    scope: dialogScope,
+                    className: 'ngdialog-theme-default discard-draft-modal'
+                });
+                dialogScope.cancel = function () {
+                    ngDialog.close(dialog.id);
+                };
+                dialogScope.discardDraft = function () {
+                    var patientUuid = $scope.patient ? $scope.patient.uuid : null;
+                    var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
+                    formDraftService.discardDraft(patientUuid, providerUuid).then(function () {
+                        $scope.formDraft.hasDrafts = false;
+                        $scope.formDraft.draftDate = null;
+                        $scope.formDraft.draftTime = null;
+                        $rootScope.draftData = null;
+                        $rootScope.resumeDraftOnLoad = false;
+                        $rootScope.resumeDraftPatientUuid = null;
+                        $rootScope.draftDiscarded = true;
+                        ngDialog.close(dialog.id);
+                    });
+                };
             };
 
             var checkForExistingDrafts = function () {

--- a/ui/app/clinical/dashboard/controllers/patientDashboardController.js
+++ b/ui/app/clinical/dashboard/controllers/patientDashboardController.js
@@ -62,6 +62,8 @@ angular.module('bahmni.clinical')
                 });
             };
 
+            var discardSuccessTimeout;
+
             $scope.confirmDiscardDraft = function () {
                 var dialogScope = $scope.$new();
                 var dialog = ngDialog.open({
@@ -88,9 +90,11 @@ angular.module('bahmni.clinical')
                         $state.dirtyConsultationForm = false;
                         $rootScope.draftDiscarded = true;
                         ngDialog.close(dialog.id);
-                        $timeout(function () {
+                        discardSuccessTimeout = $timeout(function () {
                             $scope.formDraft.discardSuccess = false;
                         }, 5000);
+                    }, function () {
+                        ngDialog.close(dialog.id);
                     });
                 };
             };
@@ -181,6 +185,9 @@ angular.module('bahmni.clinical')
                 cleanUpListenerSaveSuccessful();
                 cleanUpListenerSaveStarted();
                 cleanUpListenerPrintDashboard();
+                if (discardSuccessTimeout) {
+                    $timeout.cancel(discardSuccessTimeout);
+                }
             });
 
             var addTabNameToParams = function (board) {

--- a/ui/app/clinical/dashboard/views/dashboard.html
+++ b/ui/app/clinical/dashboard/views/dashboard.html
@@ -1,5 +1,18 @@
 <patient-context patient="patient" show-name-and-image="tabBeingPrinted.printing.showNameAndImage" class="dashboard-consultation" is-consultation="!stateChange()"></patient-context>
 
+<div ng-if="enableFormDraftFeature && formDraft.discardSuccess" class="draft-discard-success-container">
+    <div class="bx--inline-notification bx--inline-notification--success bx--inline-notification--low-contrast" role="status">
+        <div class="bx--inline-notification__details">
+            <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true" class="bx--inline-notification__icon">
+                <path d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2ZM14,21.5l-5-5,1.41-1.41L14,18.67l7.59-7.58L23,12.5Z"></path>
+            </svg>
+            <div class="bx--inline-notification__text-wrapper">
+                <p class="bx--inline-notification__title">{{ 'DRAFT_DISCARDED_SUCCESS' | translate }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div ng-if="enableFormDraftFeature && stateChange() && formDraft.hasDrafts" class="bx--inline-notification bx--inline-notification--info draft-notification" role="status">
     <div class="bx--notification__details">
         <div class="bx--notification__icon">ℹ</div>

--- a/ui/app/clinical/dashboard/views/dashboard.html
+++ b/ui/app/clinical/dashboard/views/dashboard.html
@@ -10,7 +10,7 @@
     </div>
     <div class="bx--notification__action-button">
         <button class="draft-action-button draft-resume-button" ng-click="resumeDraft()">{{ 'RESUME' | translate }}</button>
-        <button class="draft-action-button draft-discard-button">{{ 'DISCARD_DRAFT' | translate }}</button>
+        <button class="draft-action-button draft-discard-button" ng-click="confirmDiscardDraft()">{{ 'DISCARD_DRAFT' | translate }}</button>
     </div>
 </div>
 

--- a/ui/app/clinical/dashboard/views/discardDraftConfirmation.html
+++ b/ui/app/clinical/dashboard/views/discardDraftConfirmation.html
@@ -1,0 +1,15 @@
+<div class="discard-draft-dialog">
+    <div class="discard-draft-header">
+        <h2 class="discard-draft-title">{{'DISCARD_DRAFT' | translate}}</h2>
+        <button class="ngdialog-close" aria-label="Close dialog">
+            <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 32 32" class="bx--modal-close__icon"><path d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"></path></svg>
+        </button>
+    </div>
+    <div class="discard-draft-body">
+        <p>{{'DISCARD_DRAFT_CONFIRM_MESSAGE' | translate}}</p>
+    </div>
+    <div class="discard-draft-buttons">
+        <button id="discard-draft-cancel-button" class="discard-draft-cancel-btn" ng-click="cancel()">{{'CANCEL' | translate}}</button>
+        <button id="discard-draft-confirm-button" class="discard-draft-confirm-btn" ng-click="discardDraft()">{{'DISCARD' | translate}}</button>
+    </div>
+</div>

--- a/ui/app/clinical/dashboard/views/discardDraftConfirmation.html
+++ b/ui/app/clinical/dashboard/views/discardDraftConfirmation.html
@@ -1,7 +1,7 @@
 <div class="discard-draft-dialog">
     <div class="discard-draft-header">
         <h2 class="discard-draft-title">{{'DISCARD_DRAFT' | translate}}</h2>
-        <button class="ngdialog-close" aria-label="Close dialog">
+        <button class="ngdialog-close" aria-label="Close dialog" ng-click="cancel()">
             <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 32 32" class="bx--modal-close__icon"><path d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"></path></svg>
         </button>
     </div>

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -443,6 +443,7 @@
   "DISCARD_DRAFT": "Discard Draft",
   "DISCARD_DRAFT_CONFIRM_MESSAGE": "The saved draft for observation forms will be removed and cannot be restored.",
   "DISCARD": "Discard",
+  "DRAFT_DISCARDED_SUCCESS": "The saved draft session is discarded",
   "FORMS_DRAFT_BANNER_TITLE": "Observation Forms are in Progress",
   "FORMS_DRAFT_BANNER_SUBTITLE": "Your inputs were saved as a draft on {{ draftDate }} at {{ draftTime }}. Click Resume to continue where you left off or Discard Draft to start over."
 }

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -441,6 +441,8 @@
   "NO_ALLERGIES_MESSAGE": "No allergies recorded for this patient",
   "RESUME": "Resume",
   "DISCARD_DRAFT": "Discard Draft",
+  "DISCARD_DRAFT_CONFIRM_MESSAGE": "The saved draft for observation forms will be removed and cannot be restored.",
+  "DISCARD": "Discard",
   "FORMS_DRAFT_BANNER_TITLE": "Observation Forms are in Progress",
   "FORMS_DRAFT_BANNER_SUBTITLE": "Your inputs were saved as a draft on {{ draftDate }} at {{ draftTime }}. Click Resume to continue where you left off or Discard Draft to start over."
 }

--- a/ui/app/i18n/clinical/locale_es.json
+++ b/ui/app/i18n/clinical/locale_es.json
@@ -398,6 +398,7 @@
     "DISCARD_DRAFT": "Descartar borrador",
     "DISCARD_DRAFT_CONFIRM_MESSAGE": "El borrador guardado para los formularios de observación será eliminado y no podrá ser restaurado.",
     "DISCARD": "Descartar",
+    "DRAFT_DISCARDED_SUCCESS": "La sesión de borrador guardada ha sido descartada",
     "FORMS_DRAFT_BANNER_TITLE": "Formularios de observación en progreso",
     "FORMS_DRAFT_BANNER_SUBTITLE": "Sus entradas fueron guardadas como borrador el {{ draftDate }} a las {{ draftTime }}. Haga clic en Reanudar para continuar donde lo dejó o en Descartar para empezar de nuevo."
 }

--- a/ui/app/i18n/clinical/locale_es.json
+++ b/ui/app/i18n/clinical/locale_es.json
@@ -396,6 +396,8 @@
     "DAYS_ADMITTED_MESSAGE": "Días en el hospital",
     "RESUME": "Reanudar",
     "DISCARD_DRAFT": "Descartar borrador",
+    "DISCARD_DRAFT_CONFIRM_MESSAGE": "El borrador guardado para los formularios de observación será eliminado y no podrá ser restaurado.",
+    "DISCARD": "Descartar",
     "FORMS_DRAFT_BANNER_TITLE": "Formularios de observación en progreso",
     "FORMS_DRAFT_BANNER_SUBTITLE": "Sus entradas fueron guardadas como borrador el {{ draftDate }} a las {{ draftTime }}. Haga clic en Reanudar para continuar donde lo dejó o en Descartar para empezar de nuevo."
 }

--- a/ui/app/i18n/clinical/locale_fr.json
+++ b/ui/app/i18n/clinical/locale_fr.json
@@ -432,6 +432,7 @@
     "DISCARD_DRAFT": "Rejeter le brouillon",
     "DISCARD_DRAFT_CONFIRM_MESSAGE": "Le brouillon enregistré pour les formulaires d'observation sera supprimé et ne pourra pas être restauré.",
     "DISCARD": "Rejeter",
+    "DRAFT_DISCARDED_SUCCESS": "La session de brouillon enregistrée est rejetée",
     "FORMS_DRAFT_BANNER_TITLE": "Formulaires d'observation en cours",
     "FORMS_DRAFT_BANNER_SUBTITLE": "Vos entrées ont été enregistrées comme brouillon le {{ draftDate }} à {{ draftTime }}. Cliquez sur Reprendre pour continuer là où vous vous étiez arrêté ou sur Abandonner pour recommencer."
 }

--- a/ui/app/i18n/clinical/locale_fr.json
+++ b/ui/app/i18n/clinical/locale_fr.json
@@ -430,6 +430,8 @@
     "NO_ALLERGIES_MESSAGE": "Aucune allergie enregistrée pour ce patient",
     "RESUME": "Reprendre",
     "DISCARD_DRAFT": "Rejeter le brouillon",
+    "DISCARD_DRAFT_CONFIRM_MESSAGE": "Le brouillon enregistré pour les formulaires d'observation sera supprimé et ne pourra pas être restauré.",
+    "DISCARD": "Rejeter",
     "FORMS_DRAFT_BANNER_TITLE": "Formulaires d'observation en cours",
     "FORMS_DRAFT_BANNER_SUBTITLE": "Vos entrées ont été enregistrées comme brouillon le {{ draftDate }} à {{ draftTime }}. Cliquez sur Reprendre pour continuer là où vous vous étiez arrêté ou sur Abandonner pour recommencer."
 }

--- a/ui/app/styles/clinical/_clinicalIndex.scss
+++ b/ui/app/styles/clinical/_clinicalIndex.scss
@@ -7,6 +7,7 @@
 @import "treatment/variableDoseOrders";
 @import "observations";
 @import "patientDashboard";
+@import "discardDraftConfirmation";
 @import "charts";
 @import "orders";
 @import "program";

--- a/ui/app/styles/clinical/_discardDraftConfirmation.scss
+++ b/ui/app/styles/clinical/_discardDraftConfirmation.scss
@@ -1,3 +1,64 @@
+.draft-discard-success-container {
+    position: fixed;
+    z-index: 10001;
+    display: flex;
+    justify-content: center;
+    top: 52px;
+    width: 100%;
+    left: 0;
+
+    .bx--inline-notification {
+        width: auto;
+        min-width: 18rem;
+        max-width: 38rem;
+        min-height: auto;
+        font-family: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+        font-size: 0.875rem;
+        font-weight: 400;
+        line-height: 1.28572;
+        letter-spacing: 0.16px;
+        color: #161616;
+    }
+
+    .bx--inline-notification--low-contrast.bx--inline-notification--success {
+        background: #defbe6;
+        border-left: 3px solid #198038;
+        color: #161616;
+
+        .bx--inline-notification__icon {
+            fill: #198038;
+        }
+    }
+
+    .bx--inline-notification__details {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 0.25rem 0.5rem;
+        gap: 0.25rem;
+        flex: 1;
+    }
+
+    .bx--inline-notification__icon {
+        flex-shrink: 0;
+        display: block;
+        margin-top: 0;
+    }
+
+    .bx--inline-notification__text-wrapper {
+        display: flex;
+        align-items: center;
+    }
+
+    .bx--inline-notification__title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        line-height: 1;
+        letter-spacing: 0.16px;
+        margin: 0;
+    }
+}
+
 .discard-draft-modal.ngdialog-theme-default {
     padding-top: 0;
     padding-bottom: 0;

--- a/ui/app/styles/clinical/_discardDraftConfirmation.scss
+++ b/ui/app/styles/clinical/_discardDraftConfirmation.scss
@@ -1,0 +1,121 @@
+.discard-draft-modal.ngdialog-theme-default {
+    padding-top: 0;
+    padding-bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .ngdialog-content {
+        background: #ffffff;
+        border-radius: 0 !important;
+        padding: 0;
+        width: 500px;
+        margin: 0;
+        font-family: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    .discard-draft-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 20px 20px 10px 20px;
+
+        .ngdialog-close {
+            position: relative;
+            top: auto;
+            right: auto;
+            width: 24px;
+            height: 24px;
+            flex-shrink: 0;
+            padding: 0;
+            border: none;
+            background: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #000000;
+
+            &:hover,
+            &:focus {
+                outline: 2px solid #0f62fe;
+                outline-offset: 2px;
+            }
+
+            svg {
+                width: 20px;
+                height: 20px;
+                fill: currentColor;
+            }
+        }
+    }
+
+    .discard-draft-title {
+        font-size: 20px;
+        font-weight: 400;
+        margin: 0;
+        color: #333333;
+    }
+
+    .discard-draft-body {
+        padding: 10px 20px 50px 20px;
+        font-size: 14px;
+        color: #333333;
+        line-height: 1.5;
+
+        p {
+            margin: 0;
+        }
+    }
+
+    .discard-draft-buttons {
+        display: flex;
+
+        button {
+            box-sizing: border-box;
+            font-family: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+            font-size: 0.875rem;
+            font-weight: 400;
+            line-height: 1.28572;
+            letter-spacing: 0.16px;
+            position: relative;
+            display: inline-flex;
+            flex: 1;
+            min-height: 3rem;
+            flex-shrink: 0;
+            align-items: center;
+            justify-content: space-between;
+            padding: calc(0.875rem - 3px) 63px calc(0.875rem - 3px) 15px;
+            margin: 0;
+            border: 0;
+            border-radius: 0;
+            cursor: pointer;
+            outline: none;
+            text-align: left;
+            text-decoration: none;
+            transition: background 70ms cubic-bezier(0, 0, 0.38, 0.9),
+                        box-shadow 70ms cubic-bezier(0, 0, 0.38, 0.9),
+                        border-color 70ms cubic-bezier(0, 0, 0.38, 0.9),
+                        outline 70ms cubic-bezier(0, 0, 0.38, 0.9);
+            vertical-align: top;
+            background: linear-gradient(to bottom, #FFF, #DDD);
+        }
+
+        .discard-draft-cancel-btn {
+            padding-top: 1rem;
+            padding-bottom: 2rem;
+            border-width: 1px;
+            border-style: solid;
+            border-color: rgba(0, 0, 0, 0);
+            background: #393939 !important;
+            color: #ffffff;
+        }
+
+        .discard-draft-confirm-btn {
+            padding-top: 1rem;
+            padding-bottom: 2rem;
+            background: #DA1E28 !important;
+            color: #ffffff;
+        }
+    }
+}

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -1123,6 +1123,52 @@ describe('ConceptSetPageController', function () {
                 expect(rootScope.draftData).toBeNull();
             });
 
+            it('should reset allTemplates, selectedObsTemplate and observationForms when draftDiscarded flag is set', function () {
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.draftDiscarded = true;
+                scope.allTemplates = [{uuid: 'stale-template'}];
+                scope.consultation.selectedObsTemplate = [{uuid: 'stale-obs'}];
+                scope.consultation.observationForms = [{formName: 'stale-form'}];
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: null}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.draftDiscarded).toBe(false);
+                expect(_.find(scope.consultation.selectedObsTemplate, function (t) { return t.uuid === 'stale-obs'; })).toBeUndefined();
+            });
+
+            it('should clear stale draftData when getDraft returns a draft that is already markedAsSaved', function () {
+                scope.allTemplates = [{uuid: 'some-template', label: 'T', observations: [],
+                    isDefault: function () { return false; }, alwaysShow: false, isAvailable: function () { return true; }}];
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+                rootScope.draftData = {uuid: 'old-draft-uuid', formData: '[]', markedAsSaved: false};
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: 'new-draft-uuid', markedAsSaved: true}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                expect(rootScope.draftData).toBeNull();
+            });
+
             it('should not clobber draftData when resumeDraftOnLoad is set and getDraft promise catches unhandled error', function () {
                 scope.allTemplates = [{uuid: 'some-template', label: 'T', observations: [],
                     isDefault: function () { return false; }, alwaysShow: false, isAvailable: function () { return true; }}];

--- a/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
+++ b/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
@@ -8,7 +8,7 @@ describe("patient dashboard controller", function () {
     }));
 
     var scope, spinner, _clinicalDashboardConfig, _clinicalAppConfigService, _state, _appService, _diseaseTemplateService,
-        _stateParams, _controller, _appConfig, location, filter, _rootScope, _formDraftService, _ngDialog;
+        _stateParams, _controller, _appConfig, location, filter, _rootScope, _formDraftService, _ngDialog, _timeout;
     var diseaseTemplates;
     location = {
         path: function () {
@@ -81,13 +81,14 @@ describe("patient dashboard controller", function () {
                 return value;
             });
         });
-        inject(function ($controller, $rootScope, $filter, formDraftService, ngDialog) {
+        inject(function ($controller, $rootScope, $filter, formDraftService, ngDialog, $timeout) {
             scope = $rootScope.$new();
             scope.patient = {};
             scope.visitHistory = {};
             _rootScope = $rootScope;
             _formDraftService = formDraftService;
             _ngDialog = ngDialog;
+            _timeout = $timeout;
 
             spinner = jasmine.createSpyObj('spinner', ['forPromise']);
             filter = $filter;
@@ -519,10 +520,31 @@ describe("patient dashboard controller", function () {
                 expect(scope.formDraft.hasDrafts).toBe(false);
                 expect(scope.formDraft.draftDate).toBeNull();
                 expect(scope.formDraft.draftTime).toBeNull();
+                expect(scope.formDraft.discardSuccess).toBe(true);
                 expect(_rootScope.draftData).toBeNull();
                 expect(_rootScope.resumeDraftOnLoad).toBe(false);
                 expect(_rootScope.resumeDraftPatientUuid).toBeNull();
+                expect(_rootScope.hasVisitedConsultation).toBe(false);
                 expect(_rootScope.draftDiscarded).toBe(true);
+            });
+
+            it("should hide success banner after 5 seconds", function () {
+                _formDraftService.discardDraft.and.returnValue({
+                    then: function (success) {
+                        success();
+                        return this;
+                    }
+                });
+                _rootScope.currentProvider = {uuid: 'provider-uuid'};
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+
+                scope.confirmDiscardDraft();
+                var dialogScope = _ngDialog.open.calls.mostRecent().args[0].scope;
+                dialogScope.discardDraft();
+
+                expect(scope.formDraft.discardSuccess).toBe(true);
+                _timeout.flush(5000);
+                expect(scope.formDraft.discardSuccess).toBe(false);
             });
 
             it("should close dialog only after discard API call succeeds", function () {

--- a/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
+++ b/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
@@ -566,6 +566,45 @@ describe("patient dashboard controller", function () {
                 thenCallback();
                 expect(_ngDialog.close).toHaveBeenCalledWith(fakeDialog.id);
             });
+
+            it("should close dialog when discard API call fails", function () {
+                _formDraftService.discardDraft.and.returnValue({
+                    then: function (success, error) {
+                        error();
+                        return this;
+                    }
+                });
+                _rootScope.currentProvider = {uuid: 'provider-uuid'};
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.formDraft.hasDrafts = true;
+
+                scope.confirmDiscardDraft();
+                var dialogScope = _ngDialog.open.calls.mostRecent().args[0].scope;
+                dialogScope.discardDraft();
+
+                expect(_ngDialog.close).toHaveBeenCalledWith(fakeDialog.id);
+                expect(scope.formDraft.hasDrafts).toBe(true);
+            });
+
+            it("should cancel success banner timeout on scope destroy", function () {
+                _formDraftService.discardDraft.and.returnValue({
+                    then: function (success) {
+                        success();
+                        return this;
+                    }
+                });
+                _rootScope.currentProvider = {uuid: 'provider-uuid'};
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+
+                scope.confirmDiscardDraft();
+                var dialogScope = _ngDialog.open.calls.mostRecent().args[0].scope;
+                dialogScope.discardDraft();
+
+                expect(scope.formDraft.discardSuccess).toBe(true);
+                scope.$destroy();
+                try { _timeout.flush(5000); } catch (e) {}
+                expect(scope.formDraft.discardSuccess).toBe(true);
+            });
         });
 
         it("should use dashboard-content templateUrl when dashboard-content view is configured", function () {

--- a/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
+++ b/ui/test/unit/clinical/controllers/patientDashboardController.spec.js
@@ -3,11 +3,12 @@
 describe("patient dashboard controller", function () {
     beforeEach(module('bahmni.clinical'));
     beforeEach(module(function ($provide) {
-        $provide.value('formDraftService', jasmine.createSpyObj('formDraftService', ['getDraft', 'saveDraft', 'markDraftAsSaved']));
+        $provide.value('formDraftService', jasmine.createSpyObj('formDraftService', ['getDraft', 'saveDraft', 'markDraftAsSaved', 'discardDraft']));
+        $provide.value('ngDialog', jasmine.createSpyObj('ngDialog', ['open', 'close']));
     }));
 
     var scope, spinner, _clinicalDashboardConfig, _clinicalAppConfigService, _state, _appService, _diseaseTemplateService,
-        _stateParams, _controller, _appConfig, location, filter, _rootScope, _formDraftService;
+        _stateParams, _controller, _appConfig, location, filter, _rootScope, _formDraftService, _ngDialog;
     var diseaseTemplates;
     location = {
         path: function () {
@@ -80,12 +81,13 @@ describe("patient dashboard controller", function () {
                 return value;
             });
         });
-        inject(function ($controller, $rootScope, $filter, formDraftService) {
+        inject(function ($controller, $rootScope, $filter, formDraftService, ngDialog) {
             scope = $rootScope.$new();
             scope.patient = {};
             scope.visitHistory = {};
             _rootScope = $rootScope;
             _formDraftService = formDraftService;
+            _ngDialog = ngDialog;
 
             spinner = jasmine.createSpyObj('spinner', ['forPromise']);
             filter = $filter;
@@ -443,6 +445,104 @@ describe("patient dashboard controller", function () {
                 createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
                 scope.resumeDraft();
                 expect(_state.go).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("confirmDiscardDraft", function () {
+            var fakeDialog;
+            beforeEach(function () {
+                fakeDialog = {id: 'dialog-1'};
+                _ngDialog.open.and.returnValue(fakeDialog);
+                _formDraftService.getDraft.and.returnValue({
+                    then: function () { return this; },
+                    catch: function () { return this; }
+                });
+            });
+
+            it("should open a confirmation dialog when confirmDiscardDraft is called", function () {
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.confirmDiscardDraft();
+                expect(_ngDialog.open).toHaveBeenCalled();
+            });
+
+            it("should close dialog when cancel is invoked", function () {
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.confirmDiscardDraft();
+                var dialogScope = _ngDialog.open.calls.mostRecent().args[0].scope;
+                dialogScope.cancel();
+                expect(_ngDialog.close).toHaveBeenCalledWith(fakeDialog.id);
+            });
+
+            it("should not call discardDraft service or change draft state when cancel is invoked", function () {
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.formDraft.hasDrafts = true;
+                scope.formDraft.draftDate = '10 Apr 2026';
+                scope.formDraft.draftTime = '10:00 AM';
+                _rootScope.draftData = {uuid: 'some-draft'};
+
+                scope.confirmDiscardDraft();
+                var dialogScope = _ngDialog.open.calls.mostRecent().args[0].scope;
+                dialogScope.cancel();
+
+                expect(_formDraftService.discardDraft).not.toHaveBeenCalled();
+                expect(scope.formDraft.hasDrafts).toBe(true);
+                expect(scope.formDraft.draftDate).toBe('10 Apr 2026');
+                expect(scope.formDraft.draftTime).toBe('10:00 AM');
+                expect(_rootScope.draftData).toEqual({uuid: 'some-draft'});
+            });
+
+            it("should not call discardDraft service when dialog is opened but not confirmed", function () {
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.confirmDiscardDraft();
+                expect(_formDraftService.discardDraft).not.toHaveBeenCalled();
+            });
+
+            it("should call discardDraft service and clear state when discard is confirmed", function () {
+                _formDraftService.discardDraft.and.returnValue({
+                    then: function (success) {
+                        success();
+                        return this;
+                    }
+                });
+                _rootScope.currentProvider = {uuid: 'provider-uuid'};
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+                scope.formDraft.hasDrafts = true;
+                scope.formDraft.draftDate = '10 Apr 2026';
+                scope.formDraft.draftTime = '10:00 AM';
+                _rootScope.draftData = {uuid: 'some-draft'};
+
+                scope.confirmDiscardDraft();
+                var dialogScope = _ngDialog.open.calls.mostRecent().args[0].scope;
+                dialogScope.discardDraft();
+
+                expect(_formDraftService.discardDraft).toHaveBeenCalledWith('patient-uuid', 'provider-uuid');
+                expect(scope.formDraft.hasDrafts).toBe(false);
+                expect(scope.formDraft.draftDate).toBeNull();
+                expect(scope.formDraft.draftTime).toBeNull();
+                expect(_rootScope.draftData).toBeNull();
+                expect(_rootScope.resumeDraftOnLoad).toBe(false);
+                expect(_rootScope.resumeDraftPatientUuid).toBeNull();
+                expect(_rootScope.draftDiscarded).toBe(true);
+            });
+
+            it("should close dialog only after discard API call succeeds", function () {
+                var thenCallback;
+                _formDraftService.discardDraft.and.returnValue({
+                    then: function (success) {
+                        thenCallback = success;
+                        return this;
+                    }
+                });
+                _rootScope.currentProvider = {uuid: 'provider-uuid'};
+                createControllerForDraft({uuid: 'patient-uuid'}, {uuid: 'provider-uuid'});
+
+                scope.confirmDiscardDraft();
+                var dialogScope = _ngDialog.open.calls.mostRecent().args[0].scope;
+                dialogScope.discardDraft();
+
+                expect(_ngDialog.close).not.toHaveBeenCalled();
+                thenCallback();
+                expect(_ngDialog.close).toHaveBeenCalledWith(fakeDialog.id);
             });
         });
 


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=7y2aoZuxtjE42x7p8

Changes based on PR review by Claude:
MAJOR Issues

### 1. No error handling on `discardDraft` API failure

**Issue**:
`formDraftService.discardDraft(...).then(successFn)` has no rejection handler or `.catch()`. If the DELETE request fails (network error, 500, 403), the promise rejects silently. The dialog stays open with no feedback, and the user cannot tell the discard failed. The `suppressError: true` flag on the service suppresses the global error interceptor, so failure is entirely silent. The `getDraft` call in the same controller has a proper error handler and `.catch()`.

### 2. `$timeout` not tracked/cancelled on `$destroy`

**Issue**:
The `$timeout` for auto-hiding the success banner is created without storing the returned promise. If the user navigates away within 5 seconds, the `$destroy` handler runs but cannot cancel this timer. The callback fires and writes to a potentially destroyed scope. This is inconsistent with `conceptSetPageController` which stores timeout handles for cancellation.