### PR TITLE
Pooja | Hive-113099 | Add sign-off feedback changes

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -412,6 +412,9 @@ angular.module('bahmni.clinical')
                 $scope.formDraft.statusMessage = null;
                 $scope.formDraft.statusParams = {};
                 $scope.formDraft.statusError = false;
+                if ($scope.consultation) {
+                    $scope.consultation._draftCleanState = undefined;
+                }
             };
 
             var setupDirtyTracking = function () {

--- a/ui/app/clinical/consultation/views/conceptSet.html
+++ b/ui/app/clinical/consultation/views/conceptSet.html
@@ -12,7 +12,7 @@
                                     </div>
                                     <span class="saving-text">{{::'SAVING_AS_DRAFT' | translate }}</span>
                                 </div>
-                                <div class="draft-feedback-area" ng-show="enableFormDraftFeature && formDraft.hasDrafts">
+                                <div class="draft-feedback-area" ng-show="enableFormDraftFeature && formDraft.hasDrafts && !formDraft.showSpinner">
                                     <span class="draft-status-text" ng-show="!formDraft.showSpinner && formDraft.statusMessage" ng-class="{'draft-status-error': formDraft.statusError}">{{ formDraft.statusMessage | translate: formDraft.statusParams }}</span>
                                 </div>
                                 <button id="save-as-draft-button" class="save-draft-button" ng-click="saveAsDraft()" ng-show="enableFormDraftFeature" ng-disabled="!formDraft.isDirty">{{::'SAVE_AS_DRAFT'  | translate }}</button>

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -214,7 +214,7 @@
   "SAVE_CONFIRMATION_OPTION_CANCEL_KEY": "Cancel",
   "BROWSER_CLOSE_DIALOG_MESSAGE_KEY": "You might lose unsaved data",
   "POP_UP_CLOSE_DIALOG_MESSAGE_KEY": "You might lose unsaved data. Are you sure you want to leave this page?",
-  "ALERT_MESSAGE_ON_EXIT": "There is unsaved consultation data for this patient. Do you wish to Review the data or Proceed to next page?",
+  "ALERT_MESSAGE_ON_EXIT": "There is unsaved consultation data for this patient. Do you wish to Review the data or Proceed to the next page?",
   "MESSAGE_DIALOG_OPTION_COPY": "Copy Error",
   "MESSAGE_DIALOG_OPTION_OKAY": "OK",
   "MESSAGE_DIALOG_OPTION_REVIEW": "Review",

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -1203,6 +1203,31 @@ describe('ConceptSetPageController', function () {
                 expect(rootScope.draftData.uuid).toBe('draft-uuid');
             });
 
+            it('should reset _draftCleanState so Save As Draft button stays disabled when no draft exists after visit close', function () {
+                scope.allTemplates = [{uuid: 'some-template', label: 'T', observations: [],
+                    isDefault: function () { return false; }, alwaysShow: false, isAvailable: function () { return true; }}];
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                // Simulate a previously resumed draft: _draftCleanState is set to a non-empty state
+                scope.consultation._draftCleanState = 'some-old-draft-state';
+
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: null}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                // _draftCleanState must be cleared so dirty tracking baselines against the empty form
+                expect(scope.consultation._draftCleanState).toBeUndefined();
+                expect(scope.formDraft.isDirty).toBe(false);
+            });
+
             it('should call checkForExistingDrafts when patient and provider become available after controller init', function () {
                 var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
                 mockConceptSetService(conceptResponseData);


### PR DESCRIPTION
Sign-off feedback changes:
- change terminology in navigate away pop up
- Save as draft button shouldn't be enabled after draft discarded
- Saving as draft with spinner message is centered 