### PR TITLE
Nidhilesh|H-117026|H-117166|Fix for incorrect form concepts showing is Summary Tab and Instruction display control

### DIFF
--- a/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
+++ b/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
@@ -68,13 +68,17 @@ angular.module('bahmni.common.displaycontrol.observation')
                     }
                 };
 
-                var fetchFormSpecificObs = function (formName) {
+                var fetchFormSpecificObs = function (formNames) {
+                    if (!formNames) return;
                     var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
-                    var target = formName.toUpperCase();
+                    var targets = angular.isArray(formNames) ? formNames : [formNames];
+                    targets = targets.map(function (name) { return name.toUpperCase(); });
+
                     $scope.bahmniObservations.forEach(function (bahmniObs) {
                         bahmniObs.value = _.filter(bahmniObs.value, function (observation) {
-                            return observation.formFieldPath &&
-                                getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase() === target;
+                            if (!observation.formFieldPath) return false;
+                            var obsFormName = getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase();
+                            return targets.includes(obsFormName);
                         });
                     });
                     $scope.bahmniObservations = _.filter($scope.bahmniObservations, function (bahmniObs) {

--- a/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
+++ b/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
@@ -71,14 +71,15 @@ angular.module('bahmni.common.displaycontrol.observation')
                 var fetchFormSpecificObs = function (formName) {
                     var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
                     var target = formName.toUpperCase();
-                    $scope.bahmniObservations = _.filter($scope.bahmniObservations, function (bahmniObs) {
+                    $scope.bahmniObservations.forEach(function (bahmniObs) {
                         bahmniObs.value = _.filter(bahmniObs.value, function (observation) {
                             return observation.formFieldPath &&
                                 getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase() === target;
                         });
+                    });
+                    $scope.bahmniObservations = _.filter($scope.bahmniObservations, function (bahmniObs) {
                         return bahmniObs.value.length > 0;
                     });
-                    console.log("$scope.bahmniObservations -- ", $scope.bahmniObservations);
                 };
 
                 var fetchObservations = function () {

--- a/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
+++ b/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
@@ -69,20 +69,14 @@ angular.module('bahmni.common.displaycontrol.observation')
                 };
 
                 var fetchFormSpecificObs = function (formName) {
-                    var obsFormNameAndVersion;
                     var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
-                    $scope.bahmniObservations.forEach(function (bahmniObs, index) {
+                    var target = formName.toUpperCase();
+                    $scope.bahmniObservations = _.filter($scope.bahmniObservations, function (bahmniObs) {
                         bahmniObs.value = _.filter(bahmniObs.value, function (observation) {
-                            if (observation.formFieldPath) {
-                                obsFormNameAndVersion = getFormNameAndVersion(observation.formFieldPath);
-                                if (formName.toUpperCase() === obsFormNameAndVersion.formName.toUpperCase()) {
-                                    return observation;
-                                }
-                            }
+                            return observation.formFieldPath &&
+                                getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase() === target;
                         });
-                        if (bahmniObs.value.length <= 0) {
-                            $scope.bahmniObservations.splice(index, 1);
-                        }
+                        return bahmniObs.value.length > 0;
                     });
                     console.log("$scope.bahmniObservations -- ", $scope.bahmniObservations);
                 };

--- a/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
+++ b/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
@@ -260,15 +260,15 @@ describe("BahmniObservation", function () {
                     formFieldPath: "form2"
                 },
             ];
-            var formResponse = { 
-                    data: { 
+            var formResponse = {
+                    data: {
                         resources: [
-                            { value: 'form1' }, 
+                            { value: 'form1' },
                             { value: 'form2' }
-                        ] 
-                    } 
+                        ]
+                    }
                 };
-            
+
             mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond(formResponse);
             mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
 
@@ -276,10 +276,196 @@ describe("BahmniObservation", function () {
             scope.$digest();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
-        
+
             expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(1);
             expect(compiledElementScope.bahmniObservations[0].value[0].concept.name).toEqual("Surgeon");
             expect(compiledElementScope.bahmniObservations[0].value[0].formFieldPath).toEqual("form1");
+        });
+
+        it("should filter out every date group when none of the observations belong to the configured form", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {
+                conceptNames: ["Surgeon"],
+                filterByFormName: "form1"
+            };
+            scope.section = {};
+            scope.observations = [
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form2",
+                    encounterDateTime: "2026-01-01T10:00:00"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form2",
+                    encounterDateTime: "2026-02-01T10:00:00"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form2",
+                    encounterDateTime: "2026-03-01T10:00:00"
+                }
+            ];
+
+            mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond({data: {}});
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.bahmniObservations.length).toEqual(0);
+        });
+
+        it("should filter observations inside every date group, not just the first one", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {
+                conceptNames: ["Surgeon"],
+                filterByFormName: "form1"
+            };
+            scope.section = {};
+            scope.observations = [
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form2",
+                    encounterDateTime: "2026-01-01T10:00:00"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form1",
+                    encounterDateTime: "2026-02-01T10:00:00"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form2",
+                    encounterDateTime: "2026-03-01T10:00:00"
+                }
+            ];
+
+            mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond({data: {}});
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.bahmniObservations.length).toEqual(1);
+            expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(1);
+            expect(compiledElementScope.bahmniObservations[0].value[0].formFieldPath).toEqual("form1");
+        });
+
+        it("should match form name from a versioned formFieldPath like 'FormName.1/2-0'", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {
+                conceptNames: ["Surgeon"],
+                filterByFormName: "Orthopaedic Operative Report"
+            };
+            scope.section = {};
+            scope.observations = [
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "Orthopaedic Operative Report.1/2-0"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "Audiology Procedure Note.1/2-0"
+                }
+            ];
+
+            mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond({data: {}});
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(1);
+            expect(compiledElementScope.bahmniObservations[0].value[0].formFieldPath).toEqual("Orthopaedic Operative Report.1/2-0");
+        });
+
+        it("should match the configured form name case-insensitively", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {
+                conceptNames: ["Surgeon"],
+                filterByFormName: "ORTHOPAEDIC OPERATIVE REPORT"
+            };
+            scope.section = {};
+            scope.observations = [
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "Orthopaedic Operative Report.1/2-0"
+                }
+            ];
+
+            mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond({data: {}});
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(1);
+        });
+
+        it("should drop observations that have no formFieldPath when filterByFormName is set", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {
+                conceptNames: ["Surgeon"],
+                filterByFormName: "form1"
+            };
+            scope.section = {};
+            scope.observations = [
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form1"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"}
+                }
+            ];
+
+            mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond({data: {}});
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(1);
+            expect(compiledElementScope.bahmniObservations[0].value[0].formFieldPath).toEqual("form1");
+        });
+
+        it("should not apply any form-name filtering when filterByFormName is absent from config", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {
+                conceptNames: ["Surgeon"]
+            };
+            scope.section = {};
+            scope.observations = [
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form1"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form2"
+                }
+            ];
+
+            mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond({data: {}});
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(2);
         });
     });
 });

--- a/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
+++ b/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 describe("BahmniObservation", function () {
     var appService, scope, $compile, mockBackend, observationsService, q, spinner, formHierarchyService, encounterService, providerInfoService, formPrintService;
     var simpleHtml = '<bahmni-observation section="section" patient="patient" is-on-dashboard="true" config="config" enrollment="enrollment" observations="observations"></bahmni-observation>';
@@ -467,5 +468,135 @@ describe("BahmniObservation", function () {
 
             expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(2);
         });
+
+        it("should only fetch observations from config specific to multiple forms when filterByFormName is an array", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {
+                conceptNames: ["Surgeon"],
+                filterByFormName: ["form1", "form3"]
+            };
+            scope.section = {};
+            scope.observations = [
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form1"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form2"
+                },
+                {
+                    concept: {name: "Surgeon", shortName: "Surgeon"},
+                    formFieldPath: "form3"
+                }
+            ];
+
+            mockBackend.expectGET("/openmrs/ws/rest/v1/bahmniie/form/allForms?v=custom:(version,name,uuid)").respond({data: {}});
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.bahmniObservations[0].value.length).toEqual(2);
+            expect(compiledElementScope.bahmniObservations[0].value[0].formFieldPath).toEqual("form1");
+            expect(compiledElementScope.bahmniObservations[0].value[1].formFieldPath).toEqual("form3");
+        });
+    });
+});
+
+describe('fetchFormSpecificObs', function () {
+    var $scope;
+    var getFormNameAndVersion;
+    beforeEach(function () {
+        $scope = {
+            bahmniObservations: [
+                { value: [
+                    { formFieldPath: 'formA.v1', concept: { name: 'A' } },
+                    { formFieldPath: 'formB.v1', concept: { name: 'B' } },
+                    { formFieldPath: 'formC.v1', concept: { name: 'C' } }
+                ] },
+                { value: [
+                    { formFieldPath: 'formB.v1', concept: { name: 'B' } },
+                    { formFieldPath: 'formD.v1', concept: { name: 'D' } }
+                ] }
+            ]
+        };
+        getFormNameAndVersion = function (formFieldPath) {
+            return { formName: formFieldPath.split('.')[0] };
+        };
+        Bahmni = { Common: { Util: { FormFieldPathUtil: { getFormNameAndVersion: getFormNameAndVersion } } } };
+    });
+
+    it('should filter by a single form name', function () {
+        var fetchFormSpecificObs = function (formNames) {
+            if (!formNames) return;
+            var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
+            var targets = Array.isArray(formNames) ? formNames : [formNames];
+            targets = targets.map(function(name) { return name.toUpperCase(); });
+            $scope.bahmniObservations.forEach(function (bahmniObs) {
+                bahmniObs.value = bahmniObs.value.filter(function (observation) {
+                    if (!observation.formFieldPath) return false;
+                    var obsFormName = getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase();
+                    return targets.includes(obsFormName);
+                });
+            });
+            $scope.bahmniObservations = $scope.bahmniObservations.filter(function (bahmniObs) {
+                return bahmniObs.value.length > 0;
+            });
+        };
+        fetchFormSpecificObs('formB');
+        expect($scope.bahmniObservations.length).toBe(2);
+        expect($scope.bahmniObservations[0].value.length).toBe(1);
+        expect($scope.bahmniObservations[0].value[0].concept.name).toBe('B');
+        expect($scope.bahmniObservations[1].value.length).toBe(1);
+        expect($scope.bahmniObservations[1].value[0].concept.name).toBe('B');
+    });
+
+    it('should filter by multiple form names', function () {
+        var fetchFormSpecificObs = function (formNames) {
+            if (!formNames) return;
+            var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
+            var targets = Array.isArray(formNames) ? formNames : [formNames];
+            targets = targets.map(function(name) { return name.toUpperCase(); });
+            $scope.bahmniObservations.forEach(function (bahmniObs) {
+                bahmniObs.value = bahmniObs.value.filter(function (observation) {
+                    if (!observation.formFieldPath) return false;
+                    var obsFormName = getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase();
+                    return targets.includes(obsFormName);
+                });
+            });
+            $scope.bahmniObservations = $scope.bahmniObservations.filter(function (bahmniObs) {
+                return bahmniObs.value.length > 0;
+            });
+        };
+        fetchFormSpecificObs(['formA', 'formD']);
+        expect($scope.bahmniObservations.length).toBe(2);
+        expect($scope.bahmniObservations[0].value.length).toBe(1);
+        expect($scope.bahmniObservations[0].value[0].concept.name).toBe('A');
+        expect($scope.bahmniObservations[1].value.length).toBe(1);
+        expect($scope.bahmniObservations[1].value[0].concept.name).toBe('D');
+    });
+
+    it('should handle null or undefined formNames gracefully', function () {
+        var fetchFormSpecificObs = function (formNames) {
+            if (!formNames) return;
+            var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
+            var targets = Array.isArray(formNames) ? formNames : [formNames];
+            targets = targets.map(function(name) { return name.toUpperCase(); });
+            $scope.bahmniObservations.forEach(function (bahmniObs) {
+                bahmniObs.value = bahmniObs.value.filter(function (observation) {
+                    if (!observation.formFieldPath) return false;
+                    var obsFormName = getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase();
+                    return targets.includes(obsFormName);
+                });
+            });
+            $scope.bahmniObservations = $scope.bahmniObservations.filter(function (bahmniObs) {
+                return bahmniObs.value.length > 0;
+            });
+        };
+        fetchFormSpecificObs(null);
+        expect($scope.bahmniObservations.length).toBe(2);
     });
 });

--- a/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
+++ b/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 describe("BahmniObservation", function () {
     var appService, scope, $compile, mockBackend, observationsService, q, spinner, formHierarchyService, encounterService, providerInfoService, formPrintService;
     var simpleHtml = '<bahmni-observation section="section" patient="patient" is-on-dashboard="true" config="config" enrollment="enrollment" observations="observations"></bahmni-observation>';
@@ -503,100 +502,5 @@ describe("BahmniObservation", function () {
             expect(compiledElementScope.bahmniObservations[0].value[0].formFieldPath).toEqual("form1");
             expect(compiledElementScope.bahmniObservations[0].value[1].formFieldPath).toEqual("form3");
         });
-    });
-});
-
-describe('fetchFormSpecificObs', function () {
-    var $scope;
-    var getFormNameAndVersion;
-    beforeEach(function () {
-        $scope = {
-            bahmniObservations: [
-                { value: [
-                    { formFieldPath: 'formA.v1', concept: { name: 'A' } },
-                    { formFieldPath: 'formB.v1', concept: { name: 'B' } },
-                    { formFieldPath: 'formC.v1', concept: { name: 'C' } }
-                ] },
-                { value: [
-                    { formFieldPath: 'formB.v1', concept: { name: 'B' } },
-                    { formFieldPath: 'formD.v1', concept: { name: 'D' } }
-                ] }
-            ]
-        };
-        getFormNameAndVersion = function (formFieldPath) {
-            return { formName: formFieldPath.split('.')[0] };
-        };
-        Bahmni = { Common: { Util: { FormFieldPathUtil: { getFormNameAndVersion: getFormNameAndVersion } } } };
-    });
-
-    it('should filter by a single form name', function () {
-        var fetchFormSpecificObs = function (formNames) {
-            if (!formNames) return;
-            var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
-            var targets = Array.isArray(formNames) ? formNames : [formNames];
-            targets = targets.map(function(name) { return name.toUpperCase(); });
-            $scope.bahmniObservations.forEach(function (bahmniObs) {
-                bahmniObs.value = bahmniObs.value.filter(function (observation) {
-                    if (!observation.formFieldPath) return false;
-                    var obsFormName = getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase();
-                    return targets.includes(obsFormName);
-                });
-            });
-            $scope.bahmniObservations = $scope.bahmniObservations.filter(function (bahmniObs) {
-                return bahmniObs.value.length > 0;
-            });
-        };
-        fetchFormSpecificObs('formB');
-        expect($scope.bahmniObservations.length).toBe(2);
-        expect($scope.bahmniObservations[0].value.length).toBe(1);
-        expect($scope.bahmniObservations[0].value[0].concept.name).toBe('B');
-        expect($scope.bahmniObservations[1].value.length).toBe(1);
-        expect($scope.bahmniObservations[1].value[0].concept.name).toBe('B');
-    });
-
-    it('should filter by multiple form names', function () {
-        var fetchFormSpecificObs = function (formNames) {
-            if (!formNames) return;
-            var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
-            var targets = Array.isArray(formNames) ? formNames : [formNames];
-            targets = targets.map(function(name) { return name.toUpperCase(); });
-            $scope.bahmniObservations.forEach(function (bahmniObs) {
-                bahmniObs.value = bahmniObs.value.filter(function (observation) {
-                    if (!observation.formFieldPath) return false;
-                    var obsFormName = getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase();
-                    return targets.includes(obsFormName);
-                });
-            });
-            $scope.bahmniObservations = $scope.bahmniObservations.filter(function (bahmniObs) {
-                return bahmniObs.value.length > 0;
-            });
-        };
-        fetchFormSpecificObs(['formA', 'formD']);
-        expect($scope.bahmniObservations.length).toBe(2);
-        expect($scope.bahmniObservations[0].value.length).toBe(1);
-        expect($scope.bahmniObservations[0].value[0].concept.name).toBe('A');
-        expect($scope.bahmniObservations[1].value.length).toBe(1);
-        expect($scope.bahmniObservations[1].value[0].concept.name).toBe('D');
-    });
-
-    it('should handle null or undefined formNames gracefully', function () {
-        var fetchFormSpecificObs = function (formNames) {
-            if (!formNames) return;
-            var getFormNameAndVersion = Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion;
-            var targets = Array.isArray(formNames) ? formNames : [formNames];
-            targets = targets.map(function(name) { return name.toUpperCase(); });
-            $scope.bahmniObservations.forEach(function (bahmniObs) {
-                bahmniObs.value = bahmniObs.value.filter(function (observation) {
-                    if (!observation.formFieldPath) return false;
-                    var obsFormName = getFormNameAndVersion(observation.formFieldPath).formName.toUpperCase();
-                    return targets.includes(obsFormName);
-                });
-            });
-            $scope.bahmniObservations = $scope.bahmniObservations.filter(function (bahmniObs) {
-                return bahmniObs.value.length > 0;
-            });
-        };
-        fetchFormSpecificObs(null);
-        expect($scope.bahmniObservations.length).toBe(2);
     });
 });


### PR DESCRIPTION
Hive Card: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionViewId=YbzpzKAcx3sCgQ2mz&projectId=HDwkhPcw8u52fC4Jy&tabId=Mysnh4x83LMjHdfES&actionId=XXnuoPDYYMRum42Xz

https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=HDwkhPcw8u52fC4Jy&actionViewId=YbzpzKAcx3sCgQ2mz&tabId=Mysnh4x83LMjHdfES&actionId=zPEL8FNeEesz6zTDa

**PR #148 Review — bahmniObservation.js form-filter fix**
Repo: cureinternational/openmrs-module-bahmniapps · Author: nidhilesh · Branch: 117206_formfilter_issue → CURE-Product-Master · Scope: 1 file, +5/-11 · State: open, mergeable

**Recommendation: APPROVE (1 info-level suggestions)**

What changed — and why it's correct
The old fetchFormSpecificObs had a classic forEach + splice bug. Walking $scope.bahmniObservations and splicing during iteration shifts indices, so the iterator skips the element immediately after every removed group. That's exactly the symptom the PR title describes: stale date-groups (form concepts from other forms) lingering on the Summary Tab when the filter was active. The fix rebuilds the array with _.filter, which sidesteps the in-place-mutation hazard entirely.

**Net performance is better, not worse:**

formName.toUpperCase() is hoisted to target (computed once, was O(N) string allocations).
splice (O(n) per removal) replaced by a single linear _.filter.
Unused outer var obsFormNameAndVersion removed.
The unconventional return observation; (truthy-coerced) inside the inner filter callback is now a proper boolean expression.
I also checked the call site ([bahmniObservation.js:44-46](vscode-webview://0hvomrik2704b6e1om4p9iimb7d5eha684tgdk50vceuv5am3qtd/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js#L44-L46)) and downstream consumers (_.isEmpty check, event:printForm handler) — all re-read $scope.bahmniObservations afresh, so switching from in-place mutation to reassignment is safe; no stale references anywhere in the file.

Test coverage in [bahmniObservation.spec.js](vscode-webview://0hvomrik2704b6e1om4p9iimb7d5eha684tgdk50vceuv5am3qtd/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js) is good — 7 cases including the exact failing scenario (should filter out every date group when none of the observations belong to the configured form), multi-group filtering, case-insensitive match, versioned formFieldPath, and missing formFieldPath.

🔵 INFO — getFormNameAndVersion re-parses the same paths
[bahmniObservation.js:74-80](vscode-webview://0hvomrik2704b6e1om4p9iimb7d5eha684tgdk50vceuv5am3qtd/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js#L74-L80)

getFormNameAndVersion(observation.formFieldPath) runs once per observation. Within one date-group, observations from the same form instance share formFieldPath (e.g. "Orthopaedic Operative Report.1/2-0"), so the split is repeated. Not a problem at current scale, but for patients with many encounters this is the cheap win:


var getFormNameAndVersion = _.memoize(Bahmni.Common.Util.FormFieldPathUtil.getFormNameAndVersion);
_.memoize keys on the first argument by default, which is the string path — fits exactly.



**Summary:** Clean, targeted fix. Bug analysis is correct, performance is improved (not regressed), tests are thorough. 

