### PR TITLE
BAH-4430: Fix allergies display control to render based on type

### DIFF
--- a/ui/app/common/displaycontrols/dashboard/models/dashboardSection.js
+++ b/ui/app/common/displaycontrols/dashboard/models/dashboardSection.js
@@ -22,13 +22,13 @@
         "conditionsList"
     ];
     var reactDisplayControls = [
-        "Allergies",
+        "allergies",
         "formsV2React",
         "ordersV2"
     ];
 
     var getViewUrl = function (section) {
-        if (reactDisplayControls.includes(section.translationKey) || reactDisplayControls.includes(section.type)) {
+        if (reactDisplayControls.includes(section.type)) {
             return DISPLAY_CONTROL_REACT_URL;
         }
         if (section.isObservation) {

--- a/ui/app/common/displaycontrols/dashboard/views/sections/nextUISection.html
+++ b/ui/app/common/displaycontrols/dashboard/views/sections/nextUISection.html
@@ -1,3 +1,3 @@
-<mfe-next-ui-patient-alergies-control ng-if="::(section.translationKey === 'Allergies')" host-data="allergyData" app-service="appService"></mfe-next-ui-patient-alergies-control>
+<mfe-next-ui-patient-alergies-control ng-if="::(section.type === 'allergies')" host-data="allergyData" app-service="appService"></mfe-next-ui-patient-alergies-control>
 <mfe-next-ui-form-display-control ng-if="::(section.type === 'formsV2React')" host-data="getSectionFormData(section)" host-api="formApi" app-service="appService"></mfe-next-ui-form-display-control>
 <mfe-next-ui-orders-display-control ng-if="::(section.type === 'ordersV2')" host-data="ordersData"  host-api="ordersApi"></mfe-next-ui-orders-display-control>


### PR DESCRIPTION
## Summary
- Reverts allergies display control routing to use `section.type === 'allergies'` instead of `section.translationKey === 'Allergies'`
- Removes `"Allergies"` (translationKey) from `reactDisplayControls` and replaces with `"allergies"` (type)
- `getViewUrl` now checks only `section.type`, removing the translationKey check introduced in HIVE-108160
- `translationKey` remains in EMR config solely for DOM id generation via the dashboard framework

## Root Cause
HIVE-108160 switched routing and rendering of the allergies React display control to use `translationKey` instead of `type`. This broke configs that only specify `"type": "allergies"` without a `translationKey`.

## Test plan
- [ ] Verify allergies display control renders with config `{ "type": "allergies", "displayOrder": 2 }` (no translationKey)
- [ ] Verify allergies display control renders with config that includes `"translationKey": "Allergies"`
- [ ] Verify other React display controls (`formsV2React`, `ordersV2`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)