### PR TITLE
Banti | Hive-111762 | Display LMP warning banner if LMP date crosses threshold value

### DIFF
--- a/ui/app/clinical/common/services/clinicalAppConfigService.js
+++ b/ui/app/clinical/common/services/clinicalAppConfigService.js
@@ -72,4 +72,8 @@ angular.module('bahmni.clinical')
         this.getVisitTypeForRetrospectiveEntries = function () {
             return appService.getAppDescriptor().getConfigValue("visitTypeForRetrospectiveEntries");
         };
+
+        this.getLmpWarningConfig = function () {
+            return appService.getAppDescriptor().getConfigValue("lmpWarningConfig") || {};
+        };
     }]);

--- a/ui/app/clinical/constants.js
+++ b/ui/app/clinical/constants.js
@@ -79,7 +79,8 @@ Bahmni.Clinical.Constants = (function () {
         adtForwardUrl: "../adt/#/patient/{{patientUuid}}/visit/{{visitUuid}}/",
         certificateHeader: "Print Header",
         careSetting: careSetting,
-        autoSaveIntervalMs: 15 * 60 * 1000
+        autoSaveIntervalMs: 15 * 60 * 1000,
+        lmpWarningThresholdDays: 28
     };
 })();
 

--- a/ui/app/clinical/constants.js
+++ b/ui/app/clinical/constants.js
@@ -79,8 +79,7 @@ Bahmni.Clinical.Constants = (function () {
         adtForwardUrl: "../adt/#/patient/{{patientUuid}}/visit/{{visitUuid}}/",
         certificateHeader: "Print Header",
         careSetting: careSetting,
-        autoSaveIntervalMs: 15 * 60 * 1000,
-        lmpWarningThresholdDays: 28
+        autoSaveIntervalMs: 15 * 60 * 1000
     };
 })();
 

--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -2,15 +2,15 @@
 
 angular.module('bahmni.clinical').controller('ConsultationController',
     ['$scope', '$rootScope', '$state', '$location', '$translate', 'clinicalAppConfigService', 'diagnosisService', 'urlHelper', 'contextChangeHandler',
-        'spinner', 'encounterService', 'messagingService', 'sessionService', 'retrospectiveEntryService', 'patientContext', '$q', '$timeout',
+        'spinner', 'encounterService', 'messagingService', 'sessionService', 'retrospectiveEntryService', 'patientContext', '$q',
         'patientVisitHistoryService', '$stateParams', '$window', 'visitHistory', 'clinicalDashboardConfig', 'appService',
         'ngDialog', '$filter', 'configurations', 'visitConfig', 'conditionsService', 'configurationService', 'auditLogService', 'confirmBox',
-        'virtualConsultService', 'adhocTeleconsultationService', 'formDraftService', 'autoSaveService', 'patientService',
+        'virtualConsultService', 'adhocTeleconsultationService', 'formDraftService', 'autoSaveService',
         function ($scope, $rootScope, $state, $location, $translate, clinicalAppConfigService, diagnosisService, urlHelper, contextChangeHandler,
-                  spinner, encounterService, messagingService, sessionService, retrospectiveEntryService, patientContext, $q, $timeout,
+                  spinner, encounterService, messagingService, sessionService, retrospectiveEntryService, patientContext, $q,
                   patientVisitHistoryService, $stateParams, $window, visitHistory, clinicalDashboardConfig, appService,
                   ngDialog, $filter, configurations, visitConfig, conditionsService, configurationService, auditLogService, confirmBox,
-                  virtualConsultService, adhocTeleconsultationService, formDraftService, autoSaveService, patientService) {
+                  virtualConsultService, adhocTeleconsultationService, formDraftService, autoSaveService) {
             var ERROR = 1;
             var DateUtil = Bahmni.Common.Util.DateUtil;
             var getPreviousActiveCondition = Bahmni.Common.Domain.Conditions.getPreviousActiveCondition;
@@ -20,8 +20,6 @@ angular.module('bahmni.clinical').controller('ConsultationController',
             $scope.showDashboardMenu = false;
             $scope.showMobileMenu = false;
 
-            $scope.lmpWarning = null;
-            $scope.showLmpWarning = false;
             $scope.stateChange = function () {
                 return $state.current.name === 'patient.dashboard.show';
             };
@@ -181,41 +179,6 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                 }
             };
 
-            var initLmpWarning = function () {
-                if (!$scope.patient || !$scope.patient.uuid) {
-                    $scope.showLmpWarning = false;
-                    return;
-                }
-
-                var isFemale = $scope.patient.gender === 'F' || $scope.patient.gender === 'Female';
-
-                if (!isFemale) {
-                    $scope.showLmpWarning = false;
-                    return;
-                }
-
-                var lmpConfig = clinicalAppConfigService.getLmpWarningConfig();
-                var conceptName = lmpConfig.conceptName || Bahmni.Common.Constants.lmpConceptName;
-                var thresholdDays = lmpConfig.thresholdDays || Bahmni.Clinical.Constants.lmpWarningThresholdDays;
-
-                patientService.getPatientLmpData($scope.patient.uuid, conceptName).then(function (lmpData) {
-                    $timeout(function () {
-                        if (lmpData && lmpData.daysSinceLmp > thresholdDays) {
-                            $scope.lmpWarning = lmpData;
-                            $scope.showLmpWarning = true;
-                        } else {
-                            $scope.showLmpWarning = false;
-                        }
-                    });
-                }).catch(function () {
-                    $scope.showLmpWarning = false;
-                });
-            };
-
-            $scope.dismissLmpWarning = function () {
-                $scope.showLmpWarning = false;
-            };
-
             var initialize = function () {
                 var appExtensions = clinicalAppConfigService.getAllConsultationBoards();
                 $scope.adtNavigationConfig = {forwardUrl: Bahmni.Clinical.Constants.adtForwardUrl, title: $translate.instant("CLINICAL_GO_TO_DASHBOARD_LABEL"), privilege: Bahmni.Clinical.Constants.adtPrivilege };
@@ -224,7 +187,6 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                 var adtNavigationConfig = appService.getAppDescriptor().getConfigValue('adtNavigationConfig');
                 Object.assign($scope.adtNavigationConfig, adtNavigationConfig);
                 setCurrentBoardBasedOnPath();
-                initLmpWarning();
             };
 
             $scope.shouldDisplaySaveConfirmDialogForStateChange = function (toState, toParams, fromState, fromParams) {

--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -2,22 +2,26 @@
 
 angular.module('bahmni.clinical').controller('ConsultationController',
     ['$scope', '$rootScope', '$state', '$location', '$translate', 'clinicalAppConfigService', 'diagnosisService', 'urlHelper', 'contextChangeHandler',
-        'spinner', 'encounterService', 'messagingService', 'sessionService', 'retrospectiveEntryService', 'patientContext', '$q',
+        'spinner', 'encounterService', 'messagingService', 'sessionService', 'retrospectiveEntryService', 'patientContext', '$q', '$timeout',
         'patientVisitHistoryService', '$stateParams', '$window', 'visitHistory', 'clinicalDashboardConfig', 'appService',
         'ngDialog', '$filter', 'configurations', 'visitConfig', 'conditionsService', 'configurationService', 'auditLogService', 'confirmBox',
-        'virtualConsultService', 'adhocTeleconsultationService', 'formDraftService', 'autoSaveService',
+        'virtualConsultService', 'adhocTeleconsultationService', 'formDraftService', 'autoSaveService', 'patientService',
         function ($scope, $rootScope, $state, $location, $translate, clinicalAppConfigService, diagnosisService, urlHelper, contextChangeHandler,
-                  spinner, encounterService, messagingService, sessionService, retrospectiveEntryService, patientContext, $q,
+                  spinner, encounterService, messagingService, sessionService, retrospectiveEntryService, patientContext, $q, $timeout,
                   patientVisitHistoryService, $stateParams, $window, visitHistory, clinicalDashboardConfig, appService,
                   ngDialog, $filter, configurations, visitConfig, conditionsService, configurationService, auditLogService, confirmBox,
-                  virtualConsultService, adhocTeleconsultationService, formDraftService, autoSaveService) {
+                  virtualConsultService, adhocTeleconsultationService, formDraftService, autoSaveService, patientService) {
             var ERROR = 1;
             var DateUtil = Bahmni.Common.Util.DateUtil;
             var getPreviousActiveCondition = Bahmni.Common.Domain.Conditions.getPreviousActiveCondition;
+
             $scope.togglePrintList = false;
             $scope.patient = patientContext.patient;
             $scope.showDashboardMenu = false;
             $scope.showMobileMenu = false;
+
+            $scope.lmpWarning = null;
+            $scope.showLmpWarning = false;
             $scope.stateChange = function () {
                 return $state.current.name === 'patient.dashboard.show';
             };
@@ -177,6 +181,41 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                 }
             };
 
+            var initLmpWarning = function () {
+                if (!$scope.patient || !$scope.patient.uuid) {
+                    $scope.showLmpWarning = false;
+                    return;
+                }
+
+                var isFemale = $scope.patient.gender === 'F' || $scope.patient.gender === 'Female';
+
+                if (!isFemale) {
+                    $scope.showLmpWarning = false;
+                    return;
+                }
+
+                var lmpConfig = clinicalAppConfigService.getLmpWarningConfig();
+                var conceptName = lmpConfig.conceptName || Bahmni.Common.Constants.lmpConceptName;
+                var thresholdDays = lmpConfig.thresholdDays || Bahmni.Clinical.Constants.lmpWarningThresholdDays;
+
+                patientService.getPatientLmpData($scope.patient.uuid, conceptName).then(function (lmpData) {
+                    $timeout(function () {
+                        if (lmpData && lmpData.daysSinceLmp > thresholdDays) {
+                            $scope.lmpWarning = lmpData;
+                            $scope.showLmpWarning = true;
+                        } else {
+                            $scope.showLmpWarning = false;
+                        }
+                    });
+                }).catch(function () {
+                    $scope.showLmpWarning = false;
+                });
+            };
+
+            $scope.dismissLmpWarning = function () {
+                $scope.showLmpWarning = false;
+            };
+
             var initialize = function () {
                 var appExtensions = clinicalAppConfigService.getAllConsultationBoards();
                 $scope.adtNavigationConfig = {forwardUrl: Bahmni.Clinical.Constants.adtForwardUrl, title: $translate.instant("CLINICAL_GO_TO_DASHBOARD_LABEL"), privilege: Bahmni.Clinical.Constants.adtPrivilege };
@@ -185,6 +224,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                 var adtNavigationConfig = appService.getAppDescriptor().getConfigValue('adtNavigationConfig');
                 Object.assign($scope.adtNavigationConfig, adtNavigationConfig);
                 setCurrentBoardBasedOnPath();
+                initLmpWarning();
             };
 
             $scope.shouldDisplaySaveConfirmDialogForStateChange = function (toState, toParams, fromState, fromParams) {

--- a/ui/app/clinical/consultation/controllers/diagnosisController.js
+++ b/ui/app/clinical/consultation/controllers/diagnosisController.js
@@ -573,6 +573,7 @@ angular.module('bahmni.clinical')
             };
 
             $scope.isRetrospectiveMode = retrospectiveEntryService.isRetrospectiveMode;
+
             init();
         }
     ]);

--- a/ui/app/clinical/consultation/controllers/treatmentController.js
+++ b/ui/app/clinical/consultation/controllers/treatmentController.js
@@ -65,5 +65,6 @@ angular.module('bahmni.clinical')
                 $scope.enrollment = $stateParams.enrollment;
                 $scope.treatmentConfig = treatmentConfig;
             };
+
             init();
         }]);

--- a/ui/app/clinical/consultation/directives/lmpWarningBanner.js
+++ b/ui/app/clinical/consultation/directives/lmpWarningBanner.js
@@ -1,0 +1,16 @@
+'use strict';
+
+angular.module('bahmni.clinical')
+    .directive('lmpWarningBanner', ['lmpWarningHelper', function (lmpWarningHelper) {
+        return {
+            restrict: 'E',
+            scope: true,
+            templateUrl: 'consultation/views/lmpWarningBanner.html',
+            controller: ['$scope', function ($scope) {
+                lmpWarningHelper.initializeLmpWarning($scope);
+                $scope.dismissLmpWarning = function () {
+                    lmpWarningHelper.dismissLmpWarning($scope);
+                };
+            }]
+        };
+    }]);

--- a/ui/app/clinical/consultation/helpers/lmpWarningHelper.js
+++ b/ui/app/clinical/consultation/helpers/lmpWarningHelper.js
@@ -1,0 +1,51 @@
+'use strict';
+
+angular.module('bahmni.clinical')
+    .factory('lmpWarningHelper', ['$timeout', '$q', 'patientService', 'clinicalAppConfigService', function ($timeout, $q, patientService, clinicalAppConfigService) {
+        return {
+            initializeLmpWarning: function (scope) {
+                if (!scope) {
+                    return;
+                }
+
+                var patient = scope.patient || (scope.consultation && scope.consultation.patient);
+
+                if (!patient || !patient.uuid) {
+                    return;
+                }
+
+                if (patient.gender !== 'F') {
+                    scope.showLmpWarning = false;
+                    return;
+                }
+
+                var lmpConfig = clinicalAppConfigService.getLmpWarningConfig();
+                var conceptName = lmpConfig.conceptName || Bahmni.Common.Constants.lmpConceptName;
+                var thresholdDays = lmpConfig.thresholdDays || Bahmni.Clinical.Constants.lmpWarningThresholdDays;
+
+                patientService.getPatientLmpData(patient.uuid, conceptName).then(function (lmpData) {
+                    if (lmpData && lmpData.daysSinceLmp > thresholdDays) {
+                        scope.showLmpWarning = true;
+                        scope.lmpWarning = {
+                            daysSinceLmp: lmpData.daysSinceLmp
+                        };
+                    } else {
+                        scope.showLmpWarning = false;
+                    }
+
+                    if (!scope.$$phase) {
+                        scope.$apply();
+                    }
+                }).catch(function () {
+                    scope.showLmpWarning = false;
+                    if (!scope.$$phase) {
+                        scope.$apply();
+                    }
+                });
+            },
+
+            dismissLmpWarning: function (scope) {
+                scope.showLmpWarning = false;
+            }
+        };
+    }]);

--- a/ui/app/clinical/consultation/helpers/lmpWarningHelper.js
+++ b/ui/app/clinical/consultation/helpers/lmpWarningHelper.js
@@ -1,7 +1,28 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .factory('lmpWarningHelper', ['$timeout', '$q', 'patientService', 'clinicalAppConfigService', function ($timeout, $q, patientService, clinicalAppConfigService) {
+    .factory('lmpWarningHelper', ['$q', 'patientService', 'clinicalAppConfigService', function ($q, patientService, clinicalAppConfigService) {
+        var getResolvedLmpConfig = function () {
+            var config = clinicalAppConfigService.getLmpWarningConfig();
+            var conceptName = config.conceptName;
+            var thresholdDays = config.thresholdDays;
+
+            if (!conceptName || !thresholdDays) {
+                return null;
+            }
+
+            return {
+                conceptName: conceptName,
+                thresholdDays: thresholdDays
+            };
+        };
+
+        var applyScope = function (scope) {
+            if (!scope.$$phase) {
+                scope.$apply();
+            }
+        };
+
         return {
             initializeLmpWarning: function (scope) {
                 if (!scope) {
@@ -19,12 +40,14 @@ angular.module('bahmni.clinical')
                     return;
                 }
 
-                var lmpConfig = clinicalAppConfigService.getLmpWarningConfig();
-                var conceptName = lmpConfig.conceptName || Bahmni.Common.Constants.lmpConceptName;
-                var thresholdDays = lmpConfig.thresholdDays || Bahmni.Clinical.Constants.lmpWarningThresholdDays;
+                var lmpConfig = getResolvedLmpConfig();
+                if (!lmpConfig) {
+                    scope.showLmpWarning = false;
+                    return;
+                }
 
-                patientService.getPatientLmpData(patient.uuid, conceptName).then(function (lmpData) {
-                    if (lmpData && lmpData.daysSinceLmp > thresholdDays) {
+                patientService.getPatientLmpData(patient.uuid, lmpConfig.conceptName).then(function (lmpData) {
+                    if (lmpData && lmpData.daysSinceLmp > lmpConfig.thresholdDays) {
                         scope.showLmpWarning = true;
                         scope.lmpWarning = {
                             daysSinceLmp: lmpData.daysSinceLmp
@@ -33,14 +56,10 @@ angular.module('bahmni.clinical')
                         scope.showLmpWarning = false;
                     }
 
-                    if (!scope.$$phase) {
-                        scope.$apply();
-                    }
+                    applyScope(scope);
                 }).catch(function () {
                     scope.showLmpWarning = false;
-                    if (!scope.$$phase) {
-                        scope.$apply();
-                    }
+                    applyScope(scope);
                 });
             },
 

--- a/ui/app/clinical/consultation/helpers/lmpWarningHelper.js
+++ b/ui/app/clinical/consultation/helpers/lmpWarningHelper.js
@@ -1,28 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .factory('lmpWarningHelper', ['$q', 'patientService', 'clinicalAppConfigService', function ($q, patientService, clinicalAppConfigService) {
-        var getResolvedLmpConfig = function () {
-            var config = clinicalAppConfigService.getLmpWarningConfig();
-            var conceptName = config.conceptName;
-            var thresholdDays = config.thresholdDays;
-
-            if (!conceptName || !thresholdDays) {
-                return null;
-            }
-
-            return {
-                conceptName: conceptName,
-                thresholdDays: thresholdDays
-            };
-        };
-
-        var applyScope = function (scope) {
-            if (!scope.$$phase) {
-                scope.$apply();
-            }
-        };
-
+    .factory('lmpWarningHelper', ['patientService', 'clinicalAppConfigService', function (patientService, clinicalAppConfigService) {
         return {
             initializeLmpWarning: function (scope) {
                 if (!scope) {
@@ -31,23 +10,19 @@ angular.module('bahmni.clinical')
 
                 var patient = scope.patient || (scope.consultation && scope.consultation.patient);
 
-                if (!patient || !patient.uuid) {
-                    return;
-                }
-
-                if (patient.gender !== 'F') {
+                if (!patient || !patient.uuid || patient.gender !== 'F') {
                     scope.showLmpWarning = false;
                     return;
                 }
 
-                var lmpConfig = getResolvedLmpConfig();
-                if (!lmpConfig) {
+                var config = clinicalAppConfigService.getLmpWarningConfig();
+                if (!config.conceptName || !config.thresholdDays) {
                     scope.showLmpWarning = false;
                     return;
                 }
 
-                patientService.getPatientLmpData(patient.uuid, lmpConfig.conceptName).then(function (lmpData) {
-                    if (lmpData && lmpData.daysSinceLmp > lmpConfig.thresholdDays) {
+                patientService.getPatientLmpData(patient.uuid, config.conceptName).then(function (lmpData) {
+                    if (lmpData && lmpData.daysSinceLmp > config.thresholdDays) {
                         scope.showLmpWarning = true;
                         scope.lmpWarning = {
                             daysSinceLmp: lmpData.daysSinceLmp
@@ -55,11 +30,8 @@ angular.module('bahmni.clinical')
                     } else {
                         scope.showLmpWarning = false;
                     }
-
-                    applyScope(scope);
                 }).catch(function () {
                     scope.showLmpWarning = false;
-                    applyScope(scope);
                 });
             },
 

--- a/ui/app/clinical/consultation/views/bacteriology.html
+++ b/ui/app/clinical/consultation/views/bacteriology.html
@@ -1,4 +1,5 @@
 <div class="bacteriology-container" focus-on-input-errors>
+    <lmp-warning-banner></lmp-warning-banner>
     <div ng-class="{'disableBacteriologyInRetroMode':isRetrospectiveMode()}">
         <div class="infoMsgRetrospectiveModeEnabled" ng-if="isRetrospectiveMode()">
             <i class="fa fa-info-circle"></i>

--- a/ui/app/clinical/consultation/views/conceptSet.html
+++ b/ui/app/clinical/consultation/views/conceptSet.html
@@ -39,6 +39,7 @@
             </div>
         </div>
     </div>
+    <lmp-warning-banner></lmp-warning-banner>
     <concept-set-group patient="::patient" consultation="consultation" observations="consultation.observations"
                        all-templates="consultation.selectedObsTemplate" context="context"
                        auto-scroll-enabled="::scrollingEnabled" ng-if="allTemplates.length > 0">

--- a/ui/app/clinical/consultation/views/consultation.html
+++ b/ui/app/clinical/consultation/views/consultation.html
@@ -1,4 +1,5 @@
 <article class="consultation-page visit">
+    <lmp-warning-banner></lmp-warning-banner>
     <section class="messages" ng-if="isConsultationTabEmpty()">
         <h2 class="null-data-message">{{ 'CONSULTATION_PAD_EMPTY_MESSAGE'|translate }}</h2>
     </section>

--- a/ui/app/clinical/consultation/views/diagnosis.html
+++ b/ui/app/clinical/consultation/views/diagnosis.html
@@ -1,4 +1,5 @@
 <form name="diagnosisForm" alert-on-exit>
+    <lmp-warning-banner></lmp-warning-banner>
     <fieldset>
         <div class="diagnosis" focus-on-input-errors>
             <div id="selectedNodesArea">

--- a/ui/app/clinical/consultation/views/disposition.html
+++ b/ui/app/clinical/consultation/views/disposition.html
@@ -1,4 +1,5 @@
 <div class="disposition-wrapper">
+    <lmp-warning-banner></lmp-warning-banner>
     <div class="infoMsgRetrospectiveModeEnabled" ng-if="isRetrospectiveMode()">
         <i class="fa fa-info-circle"></i>
         <span ng-bind-html="'DISPOSITION_NOT_ALLOWED_IN_RETROSPECTIVE_MESSAGE'|translate"></span>

--- a/ui/app/clinical/consultation/views/investigations.html
+++ b/ui/app/clinical/consultation/views/investigations.html
@@ -1,4 +1,5 @@
 <div class="investigation">
+    <lmp-warning-banner></lmp-warning-banner>
     <div id="tabButtonRow">
     	<button ng-repeat="tab in tabs" class="{{tab.klass}}" ng-click="activateTab(tab)">{{tab.name}} </button>
     </div>

--- a/ui/app/clinical/consultation/views/lmpWarningBanner.html
+++ b/ui/app/clinical/consultation/views/lmpWarningBanner.html
@@ -1,0 +1,12 @@
+<div class="lmp-warning-banner" ng-if="showLmpWarning && lmpWarning" data-testid="lmp-warning-banner">
+    <div class="warning-content">
+        <span class="warning-icon-wrapper">
+            <i class="fa fa-circle warning-icon-circle"></i>
+            <i class="fa fa-exclamation warning-icon-mark"></i>
+        </span>
+        <span class="warning-text">{{ 'LMP_WARNING_CONSULTATION_LABEL' | translate }}<span class="warning-days">{{lmpWarning.daysSinceLmp}} {{ 'LMP_WARNING_DAYS_UNIT' | translate }}</span></span>
+        <button class="close-btn" ng-click="dismissLmpWarning()" title="Close">
+            <i class="fa fa-times"></i>
+        </button>
+    </div>
+</div>

--- a/ui/app/clinical/consultation/views/orders.html
+++ b/ui/app/clinical/consultation/views/orders.html
@@ -1,4 +1,5 @@
 <div class="order-list" alert-on-exit>
+    <lmp-warning-banner></lmp-warning-banner>
     <div ng-class="{'disableOrdersInRetroMode':isRetrospectiveMode()}">
         <div class="infoMsgRetrospectiveModeEnabled" ng-if="isRetrospectiveMode()">
             <i class="fa fa-info-circle"></i>

--- a/ui/app/clinical/consultation/views/treatment.html
+++ b/ui/app/clinical/consultation/views/treatment.html
@@ -5,6 +5,7 @@
             <div ui-view="addTreatment"></div>
         </section>
         <section class="treatment-section-right clearfix">
+            <lmp-warning-banner></lmp-warning-banner>
             <div class="pharmacist-review-banner" show-if-privilege="{{dispensePrivilege}}" ng-if="pharmacistBannerEnabled && pharmacistBanner.hasUndispensedOrders && !pharmacistBanner.confirmed">
                 <div class="pharmacist-review-banner-content">
                     <div class="pharmacist-review-banner-message">

--- a/ui/app/clinical/index.html
+++ b/ui/app/clinical/index.html
@@ -412,6 +412,8 @@
         <script src="consultation/helpers/urlHelper.js"></script>
         <script src="consultation/helpers/drugOrderHistoryHelper.js"></script>
         <script src="consultation/helpers/reactHelper.js"></script>
+        <script src="consultation/helpers/lmpWarningHelper.js"></script>
+        <script src="consultation/directives/lmpWarningBanner.js"></script>
         <script src="consultation/mappers/dispostionActionMapper.js"></script>
         <script src="consultation/mappers/labResultsMapper.js"></script>
         <script src="consultation/mappers/consultationMapper.js"></script>

--- a/ui/app/clinical/init.js
+++ b/ui/app/clinical/init.js
@@ -4,6 +4,6 @@ var Bahmni = Bahmni || {};
 Bahmni.Clinical = Bahmni.Clinical || {};
 Bahmni.Clinical.DisplayControl = Bahmni.Clinical.DisplayControl || {};
 
-angular.module('bahmni.clinical', ['bahmni.common.config', 'bahmni.common.domain', 'bahmni.common.patientContext',
+angular.module('bahmni.clinical', ['bahmni.common.config', 'bahmni.common.domain', 'bahmni.common.patient', 'bahmni.common.patientContext',
     'bahmni.common.conceptSet', 'bahmni.common.uiHelper', 'bahmni.common.gallery', 'bahmni.common.logging', 'bahmni.mfe.ipd', 'bahmni.mfe.nextUi'
 ]);

--- a/ui/app/common/constants.js
+++ b/ui/app/common/constants.js
@@ -154,7 +154,6 @@ Bahmni.Common = Bahmni.Common || {};
         labOrderNotesConcept: "Lab Order Notes",
         impressionConcept: "Impression",
         qualifiedByRelationshipType: "qualified-by",
-        lmpConceptName: "LMP Date",
         dispositionConcept: "Disposition",
         dispositionGroupConcept: "Disposition Set",
         dispositionNoteConcept: "Disposition Note",

--- a/ui/app/common/constants.js
+++ b/ui/app/common/constants.js
@@ -154,6 +154,7 @@ Bahmni.Common = Bahmni.Common || {};
         labOrderNotesConcept: "Lab Order Notes",
         impressionConcept: "Impression",
         qualifiedByRelationshipType: "qualified-by",
+        lmpConceptName: "LMP Date",
         dispositionConcept: "Disposition",
         dispositionGroupConcept: "Disposition Set",
         dispositionNoteConcept: "Disposition Note",

--- a/ui/app/common/patient/services/patientService.js
+++ b/ui/app/common/patient/services/patientService.js
@@ -64,4 +64,72 @@ angular.module('bahmni.common.patient')
                 withCredentials: true
             });
         };
+
+        this.calculateDaysSinceLmp = function (lmpDateStr) {
+            if (!lmpDateStr || !angular.isString(lmpDateStr)) {
+                return null;
+            }
+
+            var lmpDate = new Date(lmpDateStr);
+            if (isNaN(lmpDate.getTime())) {
+                return null;
+            }
+
+            var today = new Date();
+            lmpDate.setHours(0, 0, 0, 0);
+            today.setHours(0, 0, 0, 0);
+
+            if (lmpDate > today) {
+                return null;
+            }
+
+            var daysMs = today.getTime() - lmpDate.getTime();
+            return Math.floor(daysMs / (24 * 60 * 60 * 1000));
+        };
+
+        this.getPatientLmpData = function (patientUuid, conceptName) {
+            var self = this;
+
+            if (!patientUuid || !angular.isString(patientUuid)) {
+                return Bahmni.Common.Promise.when(null);
+            }
+
+            var resolvedConceptName = conceptName || Bahmni.Common.Constants.lmpConceptName;
+            var url = Bahmni.Common.Constants.openmrsObsUrl + "?patient=" + patientUuid + "&concept=" + encodeURIComponent(resolvedConceptName) + "&limit=1";
+
+            return $http.get(url, {
+                withCredentials: true
+            }).then(function (response) {
+                if (!response.data || !response.data.results || response.data.results.length === 0) {
+                    return null;
+                }
+
+                var lmpObs = response.data.results[0];
+                var lmpDateStr = lmpObs.value || lmpObs.valueText;
+
+                if (!lmpDateStr && lmpObs.display) {
+                    var displayMatch = lmpObs.display.match(/(\d{4}-\d{2}-\d{2})/);
+                    if (displayMatch && displayMatch[1]) {
+                        lmpDateStr = displayMatch[1];
+                    }
+                }
+
+                if (!lmpDateStr) {
+                    return null;
+                }
+
+                var daysSinceLmp = self.calculateDaysSinceLmp(lmpDateStr);
+
+                if (daysSinceLmp === null) {
+                    return null;
+                }
+
+                return {
+                    lmpDate: lmpDateStr,
+                    daysSinceLmp: daysSinceLmp
+                };
+            }).catch(function () {
+                return null;
+            });
+        };
     }]);

--- a/ui/app/common/patient/services/patientService.js
+++ b/ui/app/common/patient/services/patientService.js
@@ -65,31 +65,7 @@ angular.module('bahmni.common.patient')
             });
         };
 
-        this.calculateDaysSinceLmp = function (lmpDateStr) {
-            if (!lmpDateStr || !angular.isString(lmpDateStr)) {
-                return null;
-            }
-
-            var lmpDate = new Date(lmpDateStr);
-            if (isNaN(lmpDate.getTime())) {
-                return null;
-            }
-
-            var today = new Date();
-            lmpDate.setHours(0, 0, 0, 0);
-            today.setHours(0, 0, 0, 0);
-
-            if (lmpDate > today) {
-                return null;
-            }
-
-            var daysMs = today.getTime() - lmpDate.getTime();
-            return Math.floor(daysMs / (24 * 60 * 60 * 1000));
-        };
-
         this.getPatientLmpData = function (patientUuid, conceptName) {
-            var self = this;
-
             if (!patientUuid || !angular.isString(patientUuid) || !conceptName) {
                 return $q.when(null);
             }
@@ -102,25 +78,25 @@ angular.module('bahmni.common.patient')
                     return null;
                 }
 
-                var lmpObs = response.data.results[0];
-                var lmpDateStr = lmpObs.value || lmpObs.valueText;
-
-                if (!lmpDateStr && lmpObs.display) {
-                    var displayMatch = lmpObs.display.match(/(\d{4}-\d{2}-\d{2})/);
-                    if (displayMatch && displayMatch[1]) {
-                        lmpDateStr = displayMatch[1];
-                    }
-                }
-
-                if (!lmpDateStr) {
+                var lmpDateStr = response.data.results[0].value;
+                if (!lmpDateStr || !angular.isString(lmpDateStr)) {
                     return null;
                 }
 
-                var daysSinceLmp = self.calculateDaysSinceLmp(lmpDateStr);
-
-                if (daysSinceLmp === null) {
+                var lmpDate = new Date(lmpDateStr);
+                if (isNaN(lmpDate.getTime())) {
                     return null;
                 }
+
+                var today = new Date();
+                lmpDate.setHours(0, 0, 0, 0);
+                today.setHours(0, 0, 0, 0);
+
+                if (lmpDate > today) {
+                    return null;
+                }
+
+                var daysSinceLmp = Math.floor((today.getTime() - lmpDate.getTime()) / (24 * 60 * 60 * 1000));
 
                 return {
                     lmpDate: lmpDateStr,

--- a/ui/app/common/patient/services/patientService.js
+++ b/ui/app/common/patient/services/patientService.js
@@ -90,12 +90,10 @@ angular.module('bahmni.common.patient')
         this.getPatientLmpData = function (patientUuid, conceptName) {
             var self = this;
 
-            if (!patientUuid || !angular.isString(patientUuid)) {
+            if (!patientUuid || !angular.isString(patientUuid) || !conceptName) {
                 return $q.when(null);
             }
-
-            var resolvedConceptName = conceptName || Bahmni.Common.Constants.lmpConceptName;
-            var url = Bahmni.Common.Constants.openmrsObsUrl + "?patient=" + patientUuid + "&concept=" + encodeURIComponent(resolvedConceptName) + "&limit=1";
+            var url = Bahmni.Common.Constants.openmrsObsUrl + "?patient=" + patientUuid + "&concept=" + encodeURIComponent(conceptName) + "&limit=1";
 
             return $http.get(url, {
                 withCredentials: true

--- a/ui/app/common/patient/services/patientService.js
+++ b/ui/app/common/patient/services/patientService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.patient')
-    .service('patientService', ['$http', 'sessionService', 'appService', function ($http, sessionService, appService) {
+    .service('patientService', ['$http', '$q', 'sessionService', 'appService', function ($http, $q, sessionService, appService) {
         this.getPatient = function (uuid, rep) {
             if (!rep) {
                 rep = "full";
@@ -91,7 +91,7 @@ angular.module('bahmni.common.patient')
             var self = this;
 
             if (!patientUuid || !angular.isString(patientUuid)) {
-                return Bahmni.Common.Promise.when(null);
+                return $q.when(null);
             }
 
             var resolvedConceptName = conceptName || Bahmni.Common.Constants.lmpConceptName;

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -445,5 +445,8 @@
   "DISCARD": "Discard",
   "DRAFT_DISCARDED_SUCCESS": "The saved draft session is discarded",
   "FORMS_DRAFT_BANNER_TITLE": "Observation Forms are in Progress",
-  "FORMS_DRAFT_BANNER_SUBTITLE": "Your inputs were saved as a draft on {{ draftDate }} at {{ draftTime }}. Click Resume to continue where you left off or Discard Draft to start over."
+  "FORMS_DRAFT_BANNER_SUBTITLE": "Your inputs were saved as a draft on {{ draftDate }} at {{ draftTime }}. Click Resume to continue where you left off or Discard Draft to start over.",
+
+  "LMP_WARNING_CONSULTATION_LABEL": "Days since LMP - ",
+  "LMP_WARNING_DAYS_UNIT": "days"
 }

--- a/ui/app/i18n/clinical/locale_es.json
+++ b/ui/app/i18n/clinical/locale_es.json
@@ -400,5 +400,8 @@
     "DISCARD": "Descartar",
     "DRAFT_DISCARDED_SUCCESS": "La sesión de borrador guardada ha sido descartada",
     "FORMS_DRAFT_BANNER_TITLE": "Formularios de observación en progreso",
-    "FORMS_DRAFT_BANNER_SUBTITLE": "Sus entradas fueron guardadas como borrador el {{ draftDate }} a las {{ draftTime }}. Haga clic en Reanudar para continuar donde lo dejó o en Descartar para empezar de nuevo."
+    "FORMS_DRAFT_BANNER_SUBTITLE": "Sus entradas fueron guardadas como borrador el {{ draftDate }} a las {{ draftTime }}. Haga clic en Reanudar para continuar donde lo dejó o en Descartar para empezar de nuevo.",
+
+    "LMP_WARNING_CONSULTATION_LABEL": "Días desde FUM - ",
+    "LMP_WARNING_DAYS_UNIT": "días"
 }

--- a/ui/app/i18n/clinical/locale_fr.json
+++ b/ui/app/i18n/clinical/locale_fr.json
@@ -434,5 +434,8 @@
     "DISCARD": "Rejeter",
     "DRAFT_DISCARDED_SUCCESS": "La session de brouillon enregistrée est rejetée",
     "FORMS_DRAFT_BANNER_TITLE": "Formulaires d'observation en cours",
-    "FORMS_DRAFT_BANNER_SUBTITLE": "Vos entrées ont été enregistrées comme brouillon le {{ draftDate }} à {{ draftTime }}. Cliquez sur Reprendre pour continuer là où vous vous étiez arrêté ou sur Abandonner pour recommencer."
+    "FORMS_DRAFT_BANNER_SUBTITLE": "Vos entrées ont été enregistrées comme brouillon le {{ draftDate }} à {{ draftTime }}. Cliquez sur Reprendre pour continuer là où vous vous étiez arrêté ou sur Abandonner pour recommencer.",
+
+    "LMP_WARNING_CONSULTATION_LABEL": "Jours depuis FUM - ",
+    "LMP_WARNING_DAYS_UNIT": "jours"
 }

--- a/ui/app/styles/common/_notifications.scss
+++ b/ui/app/styles/common/_notifications.scss
@@ -149,3 +149,110 @@ category: Components - Alerts
 		vertical-align: middle;
 	}
 }
+
+.lmp-warning-banner {
+	background-color: #FFF3CD;
+	border: 1px solid #FFEBAA;
+	border-left: 4px solid #FFC107;
+	padding: 12px 15px;
+	margin-bottom: 15px;
+	border-radius: 2px;
+
+	.warning-content {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+	}
+
+	.warning-icon-wrapper {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		margin-right: 10px;
+		flex-shrink: 0;
+		width: 24px;
+		height: 24px;
+	}
+
+	.warning-icon-circle {
+		color: #FFC107;
+		font-size: 24px;
+		position: absolute;
+	}
+
+	.warning-icon-mark {
+		color: #555555;
+		font-size: 13px;
+		font-weight: 100;
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%) scaleY(1.3);
+	}
+
+	.warning-text {
+		color: #333333;
+		font-size: 14px;
+		font-family: OpenSansSemiBold;
+		flex-grow: 1;
+		margin: 0 10px;
+
+		.warning-days {
+			color: #666666;
+			font-family: OpenSans;
+			font-weight: 400;
+		}
+	}
+
+	.close-btn {
+		background: transparent;
+		border: none;
+		color: #555555;
+		padding: 0;
+		font-size: 14px;
+		font-weight: 400;
+		flex-shrink: 0;
+		transition: opacity 0.2s ease;
+	}
+
+	@media (max-width: 768px) {
+		.warning-content {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		.warning-icon {
+			margin-right: 8px;
+		}
+
+		.warning-text {
+			width: 100%;
+			margin: 5px 0;
+		}
+
+		.close-btn {
+			align-self: flex-end;
+			margin-top: 5px;
+		}
+	}
+}
+
+.clinical-observations {
+	position: relative;
+
+	.lmp-warning-banner {
+		position: absolute;
+		top: -22px;
+		left: 290px;
+		right: 0;
+		width: auto;
+		margin: 0;
+		z-index: 5;
+	}
+
+	&:has(.lmp-warning-banner) .concept-set-panel {
+		margin-top: 100px;
+	}
+}

--- a/ui/test/unit/clinical/controllers/consultationController.spec.js
+++ b/ui/test/unit/clinical/controllers/consultationController.spec.js
@@ -4,7 +4,7 @@ describe("ConsultationController", function () {
     var scope, rootScope, state, contextChangeHandler, urlHelper, location, clinicalAppConfigService,
         stateParams, appService, ngDialog, q, appDescriptor, controller, visitConfig, _window_, clinicalDashboardConfig,
         sessionService, conditionsService, encounterService, configurations, diagnosisService, messagingService, spinnerMock,
-        auditLogService,  confirmBox, virtualConsultService, adhocTeleconsultationService;
+        auditLogService, confirmBox, virtualConsultService, adhocTeleconsultationService, patientService;
 
     var encounterData = {
         "bahmniDiagnoses": [],
@@ -146,7 +146,8 @@ describe("ConsultationController", function () {
             auditLogService: auditLogService,
             confirmBox: confirmBox,
             virtualConsultService: virtualConsultService,
-            adhocTeleconsultationService: adhocTeleconsultationService
+            adhocTeleconsultationService: adhocTeleconsultationService,
+            patientService: patientService
         });
     };
     var setUpServiceMocks = function () {
@@ -169,8 +170,13 @@ describe("ConsultationController", function () {
             },
             getDefaultVisitType: function () {
                 return "IPD";
+            },
+            getLmpWarningConfig: function () {
+                return {};
             }
         };
+        patientService = jasmine.createSpyObj('patientService', ['getPatientLmpData', 'calculateDaysSinceLmp']);
+        patientService.getPatientLmpData.and.returnValue(specUtil.simplePromise(null));
 
         sessionService = {
             getLoginLocationUuid: function () {

--- a/ui/test/unit/clinical/controllers/consultationController.spec.js
+++ b/ui/test/unit/clinical/controllers/consultationController.spec.js
@@ -4,7 +4,7 @@ describe("ConsultationController", function () {
     var scope, rootScope, state, contextChangeHandler, urlHelper, location, clinicalAppConfigService,
         stateParams, appService, ngDialog, q, appDescriptor, controller, visitConfig, _window_, clinicalDashboardConfig,
         sessionService, conditionsService, encounterService, configurations, diagnosisService, messagingService, spinnerMock,
-        auditLogService, confirmBox, virtualConsultService, adhocTeleconsultationService, patientService;
+        auditLogService, confirmBox, virtualConsultService, adhocTeleconsultationService;
 
     var encounterData = {
         "bahmniDiagnoses": [],
@@ -146,8 +146,7 @@ describe("ConsultationController", function () {
             auditLogService: auditLogService,
             confirmBox: confirmBox,
             virtualConsultService: virtualConsultService,
-            adhocTeleconsultationService: adhocTeleconsultationService,
-            patientService: patientService
+            adhocTeleconsultationService: adhocTeleconsultationService
         });
     };
     var setUpServiceMocks = function () {
@@ -170,13 +169,8 @@ describe("ConsultationController", function () {
             },
             getDefaultVisitType: function () {
                 return "IPD";
-            },
-            getLmpWarningConfig: function () {
-                return {};
             }
         };
-        patientService = jasmine.createSpyObj('patientService', ['getPatientLmpData', 'calculateDaysSinceLmp']);
-        patientService.getPatientLmpData.and.returnValue(specUtil.simplePromise(null));
 
         sessionService = {
             getLoginLocationUuid: function () {

--- a/ui/test/unit/common/patient/services/patientService.spec.js
+++ b/ui/test/unit/common/patient/services/patientService.spec.js
@@ -101,6 +101,7 @@ describe('patientService', function () {
     describe('getPatientLmpData', function () {
         it('should fetch and return LMP data successfully', function () {
             var patientUuid = 'patient-uuid-123';
+            var conceptName = 'LMP Date';
             var lmpResponse = {
                 results: [{
                     value: '2026-04-10'
@@ -109,7 +110,7 @@ describe('patientService', function () {
 
             mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-123&concept=LMP%20Date&limit=1/).respond(lmpResponse);
 
-            patientService.getPatientLmpData(patientUuid).then(function (data) {
+            patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeTruthy();
                 expect(data.lmpDate).toBe('2026-04-10');
                 expect(data.daysSinceLmp).not.toBeLessThan(0);
@@ -120,11 +121,12 @@ describe('patientService', function () {
 
         it('should return null when no observations found', function () {
             var patientUuid = 'patient-uuid-456';
+            var conceptName = 'LMP Date';
             var emptyResponse = {results: []};
 
             mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-456&concept=LMP%20Date&limit=1/).respond(emptyResponse);
 
-            patientService.getPatientLmpData(patientUuid).then(function (data) {
+            patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeNull();
             });
 
@@ -133,15 +135,24 @@ describe('patientService', function () {
 
         it('should return null for empty or null patientUuid', function () {
             var result1, result2;
-            patientService.getPatientLmpData('').then(function (data) { result1 = data; });
-            patientService.getPatientLmpData(null).then(function (data) { result2 = data; });
+            patientService.getPatientLmpData('', 'LMP Date').then(function (data) { result1 = data; });
+            patientService.getPatientLmpData(null, 'LMP Date').then(function (data) { result2 = data; });
             rootScope.$apply();
             expect(result1).toBeNull();
             expect(result2).toBeNull();
         });
 
+        it('should return null when conceptName is not provided', function () {
+            var patientUuid = 'patient-uuid-no-concept';
+            var result;
+            patientService.getPatientLmpData(patientUuid).then(function (data) { result = data; });
+            rootScope.$apply();
+            expect(result).toBeNull();
+        });
+
         it('should return null when observation value is empty', function () {
             var patientUuid = 'patient-uuid-789';
+            var conceptName = 'LMP Date';
             var responseWithoutValue = {
                 results: [{
                     value: null
@@ -150,7 +161,7 @@ describe('patientService', function () {
 
             mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-789&concept=LMP%20Date&limit=1/).respond(responseWithoutValue);
 
-            patientService.getPatientLmpData(patientUuid).then(function (data) {
+            patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeNull();
             });
 
@@ -159,10 +170,11 @@ describe('patientService', function () {
 
         it('should handle API errors gracefully', function () {
             var patientUuid = 'patient-uuid-error';
+            var conceptName = 'LMP Date';
 
             mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-error&concept=LMP%20Date&limit=1/).respond(500, 'Server Error');
 
-            patientService.getPatientLmpData(patientUuid).then(function (data) {
+            patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeNull();
             });
 
@@ -171,6 +183,7 @@ describe('patientService', function () {
 
         it('should include daysSinceLmp in returned data', function () {
             var patientUuid = 'patient-uuid-with-days';
+            var conceptName = 'LMP Date';
             var thirtyDaysAgo = new Date();
             thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
             var lmpDate = thirtyDaysAgo.toISOString().split('T')[0];
@@ -183,7 +196,7 @@ describe('patientService', function () {
 
             mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-with-days&concept=LMP%20Date&limit=1/).respond(lmpResponse);
 
-            patientService.getPatientLmpData(patientUuid).then(function (data) {
+            patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data.lmpDate).toBe(lmpDate);
                 expect(data.daysSinceLmp).toBe(30);
             });

--- a/ui/test/unit/common/patient/services/patientService.spec.js
+++ b/ui/test/unit/common/patient/services/patientService.spec.js
@@ -112,7 +112,7 @@ describe('patientService', function () {
             patientService.getPatientLmpData(patientUuid).then(function (data) {
                 expect(data).toBeTruthy();
                 expect(data.lmpDate).toBe('2026-04-10');
-                expect(data.daysSinceLmp).toBeGreaterThanOrEqual(0);
+                expect(data.daysSinceLmp).not.toBeLessThan(0);
             });
 
             mockBackend.flush();
@@ -132,11 +132,12 @@ describe('patientService', function () {
         });
 
         it('should return null for empty or null patientUuid', function () {
-            var result1 = patientService.getPatientLmpData('');
-            var result2 = patientService.getPatientLmpData(null);
-
-            expect(result1).toEqual(null);
-            expect(result2).toEqual(null);
+            var result1, result2;
+            patientService.getPatientLmpData('').then(function (data) { result1 = data; });
+            patientService.getPatientLmpData(null).then(function (data) { result2 = data; });
+            rootScope.$apply();
+            expect(result1).toBeNull();
+            expect(result2).toBeNull();
         });
 
         it('should return null when observation value is empty', function () {

--- a/ui/test/unit/common/patient/services/patientService.spec.js
+++ b/ui/test/unit/common/patient/services/patientService.spec.js
@@ -37,67 +37,6 @@ describe('patientService', function () {
         });
     });
 
-    describe('calculateDaysSinceLmp', function () {
-        it('should calculate days correctly from LMP date to today', function () {
-            var lmpDate = new Date();
-            lmpDate.setDate(lmpDate.getDate() - 30);
-            var dateStr = lmpDate.toISOString().split('T')[0];
-
-            var result = patientService.calculateDaysSinceLmp(dateStr);
-
-            expect(result).toBe(30);
-        });
-
-        it('should return 0 for LMP on today', function () {
-            var today = new Date().toISOString().split('T')[0];
-            var result = patientService.calculateDaysSinceLmp(today);
-
-            expect(result).toBe(0);
-        });
-
-        it('should return null for invalid date string', function () {
-            var result = patientService.calculateDaysSinceLmp('invalid-date');
-            expect(result).toBeNull();
-        });
-
-        it('should return null for empty string', function () {
-            var result = patientService.calculateDaysSinceLmp('');
-            expect(result).toBeNull();
-        });
-
-        it('should return null for null input', function () {
-            var result = patientService.calculateDaysSinceLmp(null);
-            expect(result).toBeNull();
-        });
-
-        it('should return null for future date', function () {
-            var futureDate = new Date();
-            futureDate.setDate(futureDate.getDate() + 5);
-            var dateStr = futureDate.toISOString().split('T')[0];
-
-            var result = patientService.calculateDaysSinceLmp(dateStr);
-            expect(result).toBeNull();
-        });
-
-        it('should calculate 28-day threshold correctly', function () {
-            var lmpDate = new Date();
-            lmpDate.setDate(lmpDate.getDate() - 28);
-            var dateStr = lmpDate.toISOString().split('T')[0];
-
-            var result = patientService.calculateDaysSinceLmp(dateStr);
-            expect(result).toBe(28);
-        });
-
-        it('should handle date with time component', function () {
-            var lmpDate = new Date();
-            lmpDate.setDate(lmpDate.getDate() - 15);
-            var dateStr = lmpDate.toISOString();  // Include time
-
-            var result = patientService.calculateDaysSinceLmp(dateStr);
-            expect(result).toBe(15);
-        });
-    });
-
     describe('getPatientLmpData', function () {
         it('should fetch and return LMP data successfully', function () {
             var patientUuid = 'patient-uuid-123';

--- a/ui/test/unit/common/patient/services/patientService.spec.js
+++ b/ui/test/unit/common/patient/services/patientService.spec.js
@@ -107,7 +107,7 @@ describe('patientService', function () {
                 }]
             };
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-123&concept=LMP&limit=1/).respond(lmpResponse);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-123&concept=LMP%20Date&limit=1/).respond(lmpResponse);
 
             patientService.getPatientLmpData(patientUuid).then(function (data) {
                 expect(data).toBeTruthy();
@@ -122,7 +122,7 @@ describe('patientService', function () {
             var patientUuid = 'patient-uuid-456';
             var emptyResponse = {results: []};
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-456&concept=LMP&limit=1/).respond(emptyResponse);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-456&concept=LMP%20Date&limit=1/).respond(emptyResponse);
 
             patientService.getPatientLmpData(patientUuid).then(function (data) {
                 expect(data).toBeNull();
@@ -147,7 +147,7 @@ describe('patientService', function () {
                 }]
             };
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-789&concept=LMP&limit=1/).respond(responseWithoutValue);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-789&concept=LMP%20Date&limit=1/).respond(responseWithoutValue);
 
             patientService.getPatientLmpData(patientUuid).then(function (data) {
                 expect(data).toBeNull();
@@ -159,8 +159,7 @@ describe('patientService', function () {
         it('should handle API errors gracefully', function () {
             var patientUuid = 'patient-uuid-error';
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-error&concept=LMP&limit=1/).respond(500, 'Server Error');
-            spyOn(console, 'log');
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-error&concept=LMP%20Date&limit=1/).respond(500, 'Server Error');
 
             patientService.getPatientLmpData(patientUuid).then(function (data) {
                 expect(data).toBeNull();
@@ -181,7 +180,7 @@ describe('patientService', function () {
                 }]
             };
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-with-days&concept=LMP&limit=1/).respond(lmpResponse);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-with-days&concept=LMP%20Date&limit=1/).respond(lmpResponse);
 
             patientService.getPatientLmpData(patientUuid).then(function (data) {
                 expect(data.lmpDate).toBe(lmpDate);

--- a/ui/test/unit/common/patient/services/patientService.spec.js
+++ b/ui/test/unit/common/patient/services/patientService.spec.js
@@ -35,5 +35,160 @@ describe('patientService', function () {
 
             mockBackend.flush();
         });
+    });
+
+    describe('calculateDaysSinceLmp', function () {
+        it('should calculate days correctly from LMP date to today', function () {
+            var lmpDate = new Date();
+            lmpDate.setDate(lmpDate.getDate() - 30);
+            var dateStr = lmpDate.toISOString().split('T')[0];
+
+            var result = patientService.calculateDaysSinceLmp(dateStr);
+
+            expect(result).toBe(30);
+        });
+
+        it('should return 0 for LMP on today', function () {
+            var today = new Date().toISOString().split('T')[0];
+            var result = patientService.calculateDaysSinceLmp(today);
+
+            expect(result).toBe(0);
+        });
+
+        it('should return null for invalid date string', function () {
+            var result = patientService.calculateDaysSinceLmp('invalid-date');
+            expect(result).toBeNull();
+        });
+
+        it('should return null for empty string', function () {
+            var result = patientService.calculateDaysSinceLmp('');
+            expect(result).toBeNull();
+        });
+
+        it('should return null for null input', function () {
+            var result = patientService.calculateDaysSinceLmp(null);
+            expect(result).toBeNull();
+        });
+
+        it('should return null for future date', function () {
+            var futureDate = new Date();
+            futureDate.setDate(futureDate.getDate() + 5);
+            var dateStr = futureDate.toISOString().split('T')[0];
+
+            var result = patientService.calculateDaysSinceLmp(dateStr);
+            expect(result).toBeNull();
+        });
+
+        it('should calculate 28-day threshold correctly', function () {
+            var lmpDate = new Date();
+            lmpDate.setDate(lmpDate.getDate() - 28);
+            var dateStr = lmpDate.toISOString().split('T')[0];
+
+            var result = patientService.calculateDaysSinceLmp(dateStr);
+            expect(result).toBe(28);
+        });
+
+        it('should handle date with time component', function () {
+            var lmpDate = new Date();
+            lmpDate.setDate(lmpDate.getDate() - 15);
+            var dateStr = lmpDate.toISOString();  // Include time
+
+            var result = patientService.calculateDaysSinceLmp(dateStr);
+            expect(result).toBe(15);
+        });
+    });
+
+    describe('getPatientLmpData', function () {
+        it('should fetch and return LMP data successfully', function () {
+            var patientUuid = 'patient-uuid-123';
+            var lmpResponse = {
+                results: [{
+                    value: '2026-04-10'
+                }]
+            };
+
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-123&concept=LMP&limit=1/).respond(lmpResponse);
+
+            patientService.getPatientLmpData(patientUuid).then(function (data) {
+                expect(data).toBeTruthy();
+                expect(data.lmpDate).toBe('2026-04-10');
+                expect(data.daysSinceLmp).toBeGreaterThanOrEqual(0);
+            });
+
+            mockBackend.flush();
+        });
+
+        it('should return null when no observations found', function () {
+            var patientUuid = 'patient-uuid-456';
+            var emptyResponse = {results: []};
+
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-456&concept=LMP&limit=1/).respond(emptyResponse);
+
+            patientService.getPatientLmpData(patientUuid).then(function (data) {
+                expect(data).toBeNull();
+            });
+
+            mockBackend.flush();
+        });
+
+        it('should return null for empty or null patientUuid', function () {
+            var result1 = patientService.getPatientLmpData('');
+            var result2 = patientService.getPatientLmpData(null);
+
+            expect(result1).toEqual(null);
+            expect(result2).toEqual(null);
+        });
+
+        it('should return null when observation value is empty', function () {
+            var patientUuid = 'patient-uuid-789';
+            var responseWithoutValue = {
+                results: [{
+                    value: null
+                }]
+            };
+
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-789&concept=LMP&limit=1/).respond(responseWithoutValue);
+
+            patientService.getPatientLmpData(patientUuid).then(function (data) {
+                expect(data).toBeNull();
+            });
+
+            mockBackend.flush();
+        });
+
+        it('should handle API errors gracefully', function () {
+            var patientUuid = 'patient-uuid-error';
+
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-error&concept=LMP&limit=1/).respond(500, 'Server Error');
+            spyOn(console, 'log');
+
+            patientService.getPatientLmpData(patientUuid).then(function (data) {
+                expect(data).toBeNull();
+            });
+
+            mockBackend.flush();
+        });
+
+        it('should include daysSinceLmp in returned data', function () {
+            var patientUuid = 'patient-uuid-with-days';
+            var thirtyDaysAgo = new Date();
+            thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+            var lmpDate = thirtyDaysAgo.toISOString().split('T')[0];
+
+            var lmpResponse = {
+                results: [{
+                    value: lmpDate
+                }]
+            };
+
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-with-days&concept=LMP&limit=1/).respond(lmpResponse);
+
+            patientService.getPatientLmpData(patientUuid).then(function (data) {
+                expect(data.lmpDate).toBe(lmpDate);
+                expect(data.daysSinceLmp).toBe(30);
+            });
+
+            mockBackend.flush();
+        });
     })
 });


### PR DESCRIPTION
# Story #111762 — LMP Warning Banner in Consultation Tabs                                                                                                                                                                                         
                                                                                                                                                                                                                                                    
  ## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  Implements a non-blocking, dismissible LMP (Last Menstrual Period) warning banner across all 8 consultation sub-tabs for female patients whose LMP exceeds the configured threshold. Both `conceptName` and `thresholdDays` must be configured in 
  `app.json` — there are no hardcoded fallback constants.
                                                                                                                                                                                                                                                    
  ---                                                                                                                                                                                                                                             

  ## Changes

  ### `openmrs-module-bahmniapps`                                                                                                                                                                                                                   
   
  **New Files**                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                  
  | File | Purpose |                                                                                                                                                                                                                                
  |------|---------|                                                                                                                                                                                                                              
  | `ui/app/clinical/consultation/helpers/lmpWarningHelper.js` | Factory service — single source of truth for LMP config reading, validation, data fetch, and scope updates. Contains `getResolvedLmpConfig()` and `applyScope()` helper methods |
  | `ui/app/clinical/consultation/directives/lmpWarningBanner.js` | AngularJS directive (`<lmp-warning-banner>`) — single reusable element used in all 8 templates |                                                                                
  | `ui/app/clinical/consultation/views/lmpWarningBanner.html` | Shared banner template — single source of truth for banner HTML |                                                                                                                  
                                                                                                                                                                                                                                                    
  **Modified Files**                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                    
  | File | Change |                                                                                                                                                                                                                               
  |------|--------|
  | `ui/app/clinical/common/services/clinicalAppConfigService.js` | Added `getLmpWarningConfig()` — reads `lmpWarningConfig` from `appDescriptor`, returns empty object if absent |
  | `ui/app/common/patient/services/patientService.js` | Added `calculateDaysSinceLmp()` and `getPatientLmpData(patientUuid, conceptName)` |                                                                                                        
  | `ui/app/styles/common/_notifications.scss` | Added `.lmp-warning-banner` styles with layered icon, gold accent border, and `.warning-days` lighter text |                                                                                       
  | `ui/app/clinical/init.js` | Added `bahmni.common.patient` to module dependencies |                                                                                                                                                              
  | `ui/app/clinical/index.html` | Added script tag for `lmpWarningBanner.js` |                                                                                                                                                                     
  | `ui/app/i18n/clinical/locale_en.json` | Added `LMP_WARNING_CONSULTATION_LABEL` and `LMP_WARNING_DAYS_UNIT` |                                                                                                                                    
  | `ui/app/i18n/clinical/locale_fr.json` | Same translation keys in French |                                                                                                                                                                       
  | `ui/app/i18n/clinical/locale_es.json` | Same translation keys in Spanish |                                                                                                                                                                      
                                                                                                                                                                                                                                                    
  **Templates updated (replaced inline banner block with directive)**                                                                                                                                                                               
  - `consultation/views/conceptSet.html`                                                                                                                                                                                                            
  - `consultation/views/treatment.html`                                                                                                                                                                                                             
  - `consultation/views/diagnosis.html`                                                                                                                                                                                                           
  - `consultation/views/investigations.html`                                                                                                                                                                                                        
  - `consultation/views/consultation.html`                                                                                                                                                                                                        
  - `consultation/views/bacteriology.html`
  - `consultation/views/orders.html`                                                                                                                                                                                                                
  - `consultation/views/disposition.html`
                                                                                                                                                                                                                                                    
  **Controllers updated (removed `lmpWarningHelper` dependency after refactor)**                                                                                                                                                                    
  - `consultationSummaryController.js`
  - `diagnosisController.js`                                                                                                                                                                                                                        
  - `orderController.js`                                                                                                                                                                                                                          
  - `treatmentController.js`
  - `dispositionController.js`                                                                                                                                                                                                                      
  - `bacteriologyController.js`
  - `conceptSetPageController.js`                                                                                                                                                                                                                   
  - `investigationController.js`                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                    
  ---
                                                                                                                                                                                                                                                    
  ### `cure-bahmni-emr`                                                                                                                                                                                                                             
   
  | File | Change |                                                                                                                                                                                                                                 
  |------|--------|                                                                                                                                                                                                                               
  | `openmrs/apps/clinical/app.json` | Added `lmpWarningConfig: { conceptName: "LMP Date", thresholdDays: 28 }` |
                                                                                                                                                                                                                                                    
  ---
                                                                                                                                                                                                                                                    
  ## Architecture Decisions                                                                                                                                                                                                                       

  ### 1. AngularJS Directive with `scope: true`                                                                                                                                                                                                     
  Consolidated the banner into a single `<lmp-warning-banner>` directive used in all 8 templates. `scope: true` (child scope with prototypical inheritance) allows the directive to access `patient` or `consultation.patient` from the parent
  controller scope.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                  
  ### 2. Config-Required (No Fallback Constants)                                                                                                                                                                                                    
  Both `conceptName` and `thresholdDays` must be configured in `app.json`'s `lmpWarningConfig`. There are no hardcoded constant fallbacks — if either parameter is missing, the banner is disabled silently. This ensures explicit configuration is
  required and prevents undefined behavior.                                                                                                                                                                                                         
   
  ### 3. Consistent naming with story #105552                                                                                                                                                                                                       
  Config key structure mirrors `lmpConfig` from `orders/v2/app.json` for consistency. The apps are separate (AngularJS vs React) and each reads its own `appDescriptor`, so separate config blocks are necessary, but the naming convention is    
  aligned.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                  
  ### 4. Observations tab special positioning                                                                                                                                                                                                       
  The banner is absolutely positioned (`top: -22px, left: 290px`) in the Observations tab to align with the right-column form area. CSS `:has(.lmp-warning-banner)` is used on `.concept-set-panel` to conditionally apply `margin-top: 100px` — so
  the form content is only pushed down when the banner is actually visible in the DOM.                                                                                                                                                              
                                                                                                                                                                                                                                                  
  ### 5. Single Source of Truth for Config                                                                                                                                                                                                          
  All LMP config reading and validation lives in `lmpWarningHelper.js`:                                                                                                                                                                           
  - `getResolvedLmpConfig()` method validates both `conceptName` and `thresholdDays` are present                                                                                                                                                    
  - Returns null if config is incomplete → feature disabled                                                                                                                                                                                         
  - No other file reads or processes lmpConfig directly                                                                                                                                                                                             
  - Directive and other components use the helper exclusively                                                                                                                                                                                       
                                                                                                                                                                                                                                                    
  ### 6. Code separation (generic vs Cure-specific)                                                                                                                                                                                                 
  - **Generic** (openmrs-module-bahmniapps): directive, helper with config validation, service methods, styles, translations                                                                                                                      
  - **Cure-specific** (cure-bahmni-emr): actual `conceptName` and `thresholdDays` values in `app.json`                                                                                                                                              
                                                                                                                                                                                                                                                    
  ---                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                    
  ## Banner Behaviour                                                                                                                                                                                                                             

  | Condition | Banner |                                                                                                                                                                                                                            
  |-----------|--------|
  | Patient gender ≠ Female | Hidden |                                                                                                                                                                                                              
  | No LMP observation recorded | Hidden |                                                                                                                                                                                                        
  | Days since LMP ≤ 28 | Hidden |                                                                                                                                                                                                                  
  | Days since LMP > 28 | Shown |
  | User clicks × | Dismissed for session |                                                                                                                                                                                                         
  | `conceptName` not configured | Disabled (feature off, no banner) |                                                                                                                                                                            
  | `thresholdDays` not configured | Disabled (feature off, no banner) |                                                                                                                                                                            
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                  
  ## Message Format                                                                                                                                                                                                                                 
   
  **"Days since LMP - " `33 days`**                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                  
  The label is rendered in `OpenSansSemiBold` (`#333333`). The number and unit are rendered in normal weight `OpenSans` (`#666666`) for visual distinction.                                                                                         
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                  
  ## Test Plan                                                                                                                                                                                                                                      
   
  1. Open a female patient with LMP recorded > 28 days ago → banner appears on all 8 tabs                                                                                                                                                           
  2. Open a female patient with LMP ≤ 28 days ago → no banner                                                                                                                                                                                     
  3. Open a male patient → no banner                                                                                                                                                                                                                
  4. Dismiss banner with × button → banner hides for the session                                                                                                                                                                                  
  5. Open a patient with no LMP observation → no banner                                                                                                                                                                                             
  6. Observations tab: verify no gap above form content when banner is hidden                                                                                                                                                                     
  7. Remove `lmpWarningConfig` from `app.json` → feature disabled, no banner, no errors                                                                                                                                                             
  8. Remove `conceptName` from config, keep `thresholdDays` → feature disabled
  9. Remove `thresholdDays` from config, keep `conceptName` → feature disabled                                                                                                                                                                      
  10. `yarn bundle` and `yarn compass` pass with no errors                                                                                                                                                                                          
   
  ---                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                  
  ## PR Feedback Addressed

  ### Feedback 1: "lmpconceptname should be a config parameter, not a constant"                                                                                                                                                                     
  ✅ **Fixed**: Removed `Bahmni.Common.Constants.lmpConceptName` fallback. `conceptName` is now config-only.
                                                                                                                                                                                                                                                    
  ### Feedback 2: "I feel this is a duplicate code, can we have this under one file/method and use it?"                                                                                                                                             
  ✅ **Fixed**: All LMP config reading consolidated into `lmpWarningHelper.js`:
  - `getResolvedLmpConfig()` method validates and returns resolved config                                                                                                                                                                           
  - Removed `initLmpWarning()` from `consultationController.js` (was duplicate)                                                                                                                                                                   
  - Removed `patientService` and `$timeout` DI from main controller (only helper uses them)                                                                                                                                                         
   
  ### Code Improvements Applied                                                                                                                                                                                                                     
  1. ✅ Removed unused `$timeout` injection from helper DI                                                                                                                                                                                        
  2. ✅ Extracted `applyScope()` helper to eliminate duplicate `scope.$apply()` logic                                                                                                                                                               
  3. ✅ Extracted `getResolvedLmpConfig()` to centralize config validation
  4. ✅ Removed hardcoded constant fallbacks for both `conceptName` and `thresholdDays`                                                                                                                                                             
