### PR TITLE
Pooja | Bug-116474 | "Save as Draft" button remains enabled after successful save when no changes are made

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -437,18 +437,18 @@ angular.module('bahmni.clinical')
                             dirtyTrackingState.postSaveRefreshTimeout = null;
                             return;
                         }
-                        var tick1State = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
-                        dirtyTrackingState.cleanState = tick1State;
-                        $scope.consultation._draftCleanState = tick1State;
+                        var partialRefreshState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                        dirtyTrackingState.cleanState = partialRefreshState;
+                        $scope.consultation._draftCleanState = partialRefreshState;
                         $scope.formDraft.isDirty = false;
                         dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
                             if (!dirtyTrackingState.postSaveRefreshPending) {
                                 dirtyTrackingState.postSaveRefreshTimeout = null;
                                 return;
                             }
-                            var tick2State = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
-                            dirtyTrackingState.cleanState = tick2State;
-                            $scope.consultation._draftCleanState = tick2State;
+                            var settledCleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                            dirtyTrackingState.cleanState = settledCleanState;
+                            $scope.consultation._draftCleanState = settledCleanState;
                             $scope.formDraft.isDirty = false;
                             dirtyTrackingState.postSaveRefreshPending = false;
                             dirtyTrackingState.postSaveRefreshTimeout = null;

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -394,26 +394,23 @@ angular.module('bahmni.clinical')
                 hasDrafts: false
             };
 
-            var suppressionWindowMs = 1500;
-
             var dirtyTrackingState = {
                 cleanState: null,
                 initialized: false,
                 watchDeregister: null,
-                suppressTracking: false,
-                suppressionUnsuppressPromise: null,
+                postSaveRefreshPending: sessionStorage.getItem('formSaveCompleted') === 'true',
                 form2ListenerState: null,
                 isSaving: false
             };
 
-            var clearDraftStatus = function () {
+            var clearDraftStatus = function (preserveCleanState) {
                 $scope.formDraft.hasDrafts = false;
                 $scope.formDraft.draftDate = null;
                 $scope.formDraft.draftTime = null;
                 $scope.formDraft.statusMessage = null;
                 $scope.formDraft.statusParams = {};
                 $scope.formDraft.statusError = false;
-                if ($scope.consultation) {
+                if ($scope.consultation && !preserveCleanState) {
                     $scope.consultation._draftCleanState = undefined;
                 }
             };
@@ -430,22 +427,18 @@ angular.module('bahmni.clinical')
                 } else {
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
-                    dirtyTrackingState.suppressTracking = true;
-                    dirtyTrackingState.suppressionUnsuppressPromise = $timeout(function () {
-                        dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
-                        $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
-                        dirtyTrackingState.suppressTracking = false;
-                        dirtyTrackingState.suppressionUnsuppressPromise = null;
-                    }, 0);
                 }
 
                 dirtyTrackingState.watchDeregister = $scope.$watch(
                     function () { return formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate); },
                     function (newVal, oldVal) {
                         if (newVal !== oldVal) {
-                            if (dirtyTrackingState.suppressTracking) {
+                            if (dirtyTrackingState.postSaveRefreshPending) {
                                 dirtyTrackingState.cleanState = newVal;
+                                $scope.consultation._draftCleanState = newVal;
                                 $scope.formDraft.isDirty = false;
+                                dirtyTrackingState.postSaveRefreshPending = false;
+                                sessionStorage.removeItem('formSaveCompleted');
                                 return;
                             }
                             $scope.formDraft.isDirty = newVal !== dirtyTrackingState.cleanState;
@@ -466,42 +459,6 @@ angular.module('bahmni.clinical')
                     function () { return $scope.enableFormDraftFeature && $scope.formDraft.isDirty && !dirtyTrackingState.isSaving && $scope.visitHistory && $scope.visitHistory.activeVisit; },
                     saveFormDraft
                 );
-            };
-
-            var suppressDirtyTrackingDuringSaveRefresh = function () {
-                dirtyTrackingState.suppressTracking = true;
-                $scope.formDraft.isDirty = false;
-                dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
-                if (dirtyTrackingState.suppressionUnsuppressPromise) {
-                    $timeout.cancel(dirtyTrackingState.suppressionUnsuppressPromise);
-                }
-                dirtyTrackingState.suppressionUnsuppressPromise = $timeout(function () {
-                    dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
-                    $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
-                    $scope.formDraft.isDirty = false;
-                    dirtyTrackingState.suppressTracking = false;
-                    dirtyTrackingState.suppressionUnsuppressPromise = null;
-                }, suppressionWindowMs);
-            };
-
-            var resetDirtyTracking = function (restartTracking) {
-                if (dirtyTrackingState.watchDeregister) {
-                    dirtyTrackingState.watchDeregister();
-                    dirtyTrackingState.watchDeregister = null;
-                }
-                formDirtyStateService.unregisterForm2SyncListeners(dirtyTrackingState.form2ListenerState);
-                dirtyTrackingState.form2ListenerState = null;
-                dirtyTrackingState.initialized = false;
-                dirtyTrackingState.suppressTracking = false;
-                if (dirtyTrackingState.suppressionUnsuppressPromise) {
-                    $timeout.cancel(dirtyTrackingState.suppressionUnsuppressPromise);
-                    dirtyTrackingState.suppressionUnsuppressPromise = null;
-                }
-                $scope.formDraft.isDirty = false;
-                $scope.consultation._draftCleanState = undefined;
-                if (restartTracking !== false) {
-                    $timeout(setupDirtyTracking, 0);
-                }
             };
 
             var saveFormDraft = function () {
@@ -639,17 +596,19 @@ angular.module('bahmni.clinical')
             };
 
             var resetDraftStateAfterSave = function () {
-                resetDirtyTracking();
-                suppressDirtyTrackingDuringSaveRefresh();
-                clearDraftStatus();
+                $scope.formDraft.isDirty = false;
+                $scope.formDraft.hasDrafts = false;
+                dirtyTrackingState.postSaveRefreshPending = true;
+                clearDraftStatus(true);
             };
             $scope.consultation.postSaveHandler.register("resetDraftStateAfterSave", resetDraftStateAfterSave);
 
             var saveSuccessfulListener = $rootScope.$on('event:save-successful', function () {
-                resetDirtyTracking();
-                suppressDirtyTrackingDuringSaveRefresh();
+                $scope.formDraft.isDirty = false;
+                $scope.formDraft.hasDrafts = false;
+                dirtyTrackingState.postSaveRefreshPending = true;
                 $scope.formDraft.showSpinner = false;
-                clearDraftStatus();
+                clearDraftStatus(true);
             });
 
             var saveStartedListener = $rootScope.$on('event:save-started', function () {
@@ -660,9 +619,6 @@ angular.module('bahmni.clinical')
             $scope.$on('$destroy', function () {
                 if (dirtyTrackingState.watchDeregister) {
                     dirtyTrackingState.watchDeregister();
-                }
-                if (dirtyTrackingState.suppressionUnsuppressPromise) {
-                    $timeout.cancel(dirtyTrackingState.suppressionUnsuppressPromise);
                 }
                 formDirtyStateService.unregisterForm2SyncListeners(dirtyTrackingState.form2ListenerState);
                 if (draftContextWatchDeregister) {

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -432,17 +432,11 @@ angular.module('bahmni.clinical')
                     if (dirtyTrackingState.postSaveRefreshTimeout) {
                         $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
                     }
-                    // Two-tick fallback: gives HTTP responses one extra JS event-loop tick
-                    // to arrive before we commit to the current state as clean.
-                    // (On first cold load, conceptSetService.getConcept takes ~20ms;
-                    // the $timeout(0) fires in ~1ms. The second tick covers the common
-                    // gap for browser-cached responses arriving at ~1-4ms.)
                     dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
                         if (!dirtyTrackingState.postSaveRefreshPending) {
                             dirtyTrackingState.postSaveRefreshTimeout = null;
-                            return; // Watcher debounce already took over
+                            return;
                         }
-                        // Tick 1: update cleanState but do NOT clear pending yet.
                         var tick1State = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                         dirtyTrackingState.cleanState = tick1State;
                         $scope.consultation._draftCleanState = tick1State;
@@ -450,9 +444,8 @@ angular.module('bahmni.clinical')
                         dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
                             if (!dirtyTrackingState.postSaveRefreshPending) {
                                 dirtyTrackingState.postSaveRefreshTimeout = null;
-                                return; // Watcher debounce already took over between tick-1 and tick-2
+                                return;
                             }
-                            // Tick 2: now safe to finalize cleanState and clear pending.
                             var tick2State = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                             dirtyTrackingState.cleanState = tick2State;
                             $scope.consultation._draftCleanState = tick2State;
@@ -468,9 +461,6 @@ angular.module('bahmni.clinical')
                     function (newVal, oldVal) {
                         if (newVal !== oldVal) {
                             if (dirtyTrackingState.postSaveRefreshPending) {
-                                // During init, track the evolving state as the new clean baseline.
-                                // Debounce: reset the clear-timeout so we finalize only after the
-                                // last async initializer (e.g. conceptSetService HTTP response) fires.
                                 dirtyTrackingState.cleanState = newVal;
                                 $scope.consultation._draftCleanState = newVal;
                                 $scope.formDraft.isDirty = false;

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -398,7 +398,8 @@ angular.module('bahmni.clinical')
                 cleanState: null,
                 initialized: false,
                 watchDeregister: null,
-                postSaveRefreshPending: sessionStorage.getItem('formSaveCompleted') === 'true',
+                postSaveRefreshPending: false,
+                postSaveRefreshTimeout: null,
                 form2ListenerState: null,
                 isSaving: false
             };
@@ -427,6 +428,39 @@ angular.module('bahmni.clinical')
                 } else {
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
+                    dirtyTrackingState.postSaveRefreshPending = true;
+                    if (dirtyTrackingState.postSaveRefreshTimeout) {
+                        $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
+                    }
+                    // Two-tick fallback: gives HTTP responses one extra JS event-loop tick
+                    // to arrive before we commit to the current state as clean.
+                    // (On first cold load, conceptSetService.getConcept takes ~20ms;
+                    // the $timeout(0) fires in ~1ms. The second tick covers the common
+                    // gap for browser-cached responses arriving at ~1-4ms.)
+                    dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                        if (!dirtyTrackingState.postSaveRefreshPending) {
+                            dirtyTrackingState.postSaveRefreshTimeout = null;
+                            return; // Watcher debounce already took over
+                        }
+                        // Tick 1: update cleanState but do NOT clear pending yet.
+                        var tick1State = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                        dirtyTrackingState.cleanState = tick1State;
+                        $scope.consultation._draftCleanState = tick1State;
+                        $scope.formDraft.isDirty = false;
+                        dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                            if (!dirtyTrackingState.postSaveRefreshPending) {
+                                dirtyTrackingState.postSaveRefreshTimeout = null;
+                                return; // Watcher debounce already took over between tick-1 and tick-2
+                            }
+                            // Tick 2: now safe to finalize cleanState and clear pending.
+                            var tick2State = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                            dirtyTrackingState.cleanState = tick2State;
+                            $scope.consultation._draftCleanState = tick2State;
+                            $scope.formDraft.isDirty = false;
+                            dirtyTrackingState.postSaveRefreshPending = false;
+                            dirtyTrackingState.postSaveRefreshTimeout = null;
+                        }, 0);
+                    }, 0);
                 }
 
                 dirtyTrackingState.watchDeregister = $scope.$watch(
@@ -434,11 +468,19 @@ angular.module('bahmni.clinical')
                     function (newVal, oldVal) {
                         if (newVal !== oldVal) {
                             if (dirtyTrackingState.postSaveRefreshPending) {
+                                // During init, track the evolving state as the new clean baseline.
+                                // Debounce: reset the clear-timeout so we finalize only after the
+                                // last async initializer (e.g. conceptSetService HTTP response) fires.
                                 dirtyTrackingState.cleanState = newVal;
                                 $scope.consultation._draftCleanState = newVal;
                                 $scope.formDraft.isDirty = false;
-                                dirtyTrackingState.postSaveRefreshPending = false;
-                                sessionStorage.removeItem('formSaveCompleted');
+                                if (dirtyTrackingState.postSaveRefreshTimeout) {
+                                    $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
+                                }
+                                dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                                    dirtyTrackingState.postSaveRefreshPending = false;
+                                    dirtyTrackingState.postSaveRefreshTimeout = null;
+                                }, 0);
                                 return;
                             }
                             $scope.formDraft.isDirty = newVal !== dirtyTrackingState.cleanState;
@@ -491,6 +533,17 @@ angular.module('bahmni.clinical')
                     $scope.formDraft.hasDrafts = true;
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
+                    dirtyTrackingState.postSaveRefreshPending = true;
+                    if (dirtyTrackingState.postSaveRefreshTimeout) {
+                        $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
+                    }
+                    dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                        dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                        $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
+                        $scope.formDraft.isDirty = false;
+                        dirtyTrackingState.postSaveRefreshPending = false;
+                        dirtyTrackingState.postSaveRefreshTimeout = null;
+                    }, 0);
                     $rootScope.$broadcast('draft:saved', {draftDate: draftDate, draftTime: draftTime});
                 }, function () {
                     $scope.formDraft.statusMessage = 'CHANGES_NOT_SAVED_KEY';
@@ -599,6 +652,17 @@ angular.module('bahmni.clinical')
                 $scope.formDraft.isDirty = false;
                 $scope.formDraft.hasDrafts = false;
                 dirtyTrackingState.postSaveRefreshPending = true;
+                if (dirtyTrackingState.postSaveRefreshTimeout) {
+                    $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
+                }
+                dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                    dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                    $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
+                    $scope.formDraft.isDirty = false;
+                    dirtyTrackingState.postSaveRefreshPending = false;
+                    dirtyTrackingState.postSaveRefreshTimeout = null;
+                    sessionStorage.removeItem('formSaveCompleted');
+                }, 0);
                 clearDraftStatus(true);
             };
             $scope.consultation.postSaveHandler.register("resetDraftStateAfterSave", resetDraftStateAfterSave);
@@ -609,6 +673,17 @@ angular.module('bahmni.clinical')
                 dirtyTrackingState.postSaveRefreshPending = true;
                 $scope.formDraft.showSpinner = false;
                 clearDraftStatus(true);
+                if (dirtyTrackingState.postSaveRefreshTimeout) {
+                    $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
+                }
+                dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                    dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                    $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
+                    $scope.formDraft.isDirty = false;
+                    dirtyTrackingState.postSaveRefreshPending = false;
+                    dirtyTrackingState.postSaveRefreshTimeout = null;
+                    sessionStorage.removeItem('formSaveCompleted');
+                }, 0);
             });
 
             var saveStartedListener = $rootScope.$on('event:save-started', function () {
@@ -619,6 +694,9 @@ angular.module('bahmni.clinical')
             $scope.$on('$destroy', function () {
                 if (dirtyTrackingState.watchDeregister) {
                     dirtyTrackingState.watchDeregister();
+                }
+                if (dirtyTrackingState.postSaveRefreshTimeout) {
+                    $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
                 }
                 formDirtyStateService.unregisterForm2SyncListeners(dirtyTrackingState.form2ListenerState);
                 if (draftContextWatchDeregister) {

--- a/ui/app/clinical/consultation/services/formDirtyStateService.js
+++ b/ui/app/clinical/consultation/services/formDirtyStateService.js
@@ -16,7 +16,7 @@ angular.module('bahmni.clinical')
                     return k.indexOf('$') !== 0;
                 });
                 if (selectedKeys.length > 0) {
-                    values.push(obs.selectedObs);
+                    values.push(selectedKeys.sort());
                 }
                 return;
             }
@@ -27,7 +27,12 @@ angular.module('bahmni.clinical')
                 return;
             }
             if (obs.value !== null && obs.value !== undefined) {
-                values.push(obs.value);
+                var val = obs.value;
+                if (val && typeof val === 'object' && val.uuid) {
+                    values.push(val.uuid);
+                } else {
+                    values.push(val);
+                }
             }
         };
 

--- a/ui/app/common/concept-set/directives/conceptSet.js
+++ b/ui/app/common/concept-set/directives/conceptSet.js
@@ -283,7 +283,7 @@ angular.module('bahmni.common.conceptSet')
                     return conceptSetService.getConcept({
                         name: conceptSetName,
                         v: "bahmni"
-                    }).then(function (response) {
+                    }, true).then(function (response) {
                         $scope.conceptSet = response.data.results[0];
                         $scope.rootObservation = $scope.conceptSet ? observationMapper.map($scope.observations, $scope.conceptSet, conceptSetUIConfig) : null;
                         if ($scope.rootObservation) {

--- a/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
+++ b/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
@@ -24,7 +24,7 @@ describe('formDirtyStateService', function () {
             expect(values).toEqual([]);
         });
 
-        it('should collect multiSelect observation values', function () {
+        it('should collect multiSelect observation values as sorted keys', function () {
             var values = [];
             var obs = {
                 isMultiSelect: true,
@@ -32,7 +32,7 @@ describe('formDirtyStateService', function () {
             };
             formDirtyStateService.collectObsValues(obs, values);
             expect(values.length).toBe(1);
-            expect(values[0]).toEqual({option1: true, option2: false});
+            expect(values[0]).toEqual(['option1', 'option2']);
         });
 
         it('should ignore Angular $ prefixed keys in multiSelect', function () {
@@ -43,7 +43,7 @@ describe('formDirtyStateService', function () {
             };
             formDirtyStateService.collectObsValues(obs, values);
             expect(values.length).toBe(1);
-            expect(values[0]).toEqual({option1: true, $special: 'ignore'});
+            expect(values[0]).toEqual(['option1']);
         });
 
         it('should not collect multiSelect with no selected keys', function () {


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=t7R8crQGbvWqPSwpH

Fixes in this PR:
- For Issue#5: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=t7R8crQGbvWqPSwpH

Solution: 
postSaveRefreshPending + postSaveRefreshTimeout — a flag + cancellable $timeout handle.

 Two-phase snapshot mechanism (in setupDirtyTracking and after save):
 Save completes
    → postSaveRefreshPending = true
    → Snapshot cleanState immediately (pre-refresh)
    → $timeout phase 1: form may be partially re-rendered;
        snapshot **partialRefreshState**, set isDirty = false
    → $timeout phase 2: AngularJS digest has fully settled;
        snapshot **settledCleanState** as final cleanState, clear postSaveRefreshPending

 AngularJS sometimes needs two digest cycles to fully propagate server data into all watchers. **partialRefreshState** captures the form mid-render; **settledCleanState** captures the final stable state and becomes the authoritative clean baseline that future edits are compared against.
 
 Watcher debounce — if the $watch fires while postSaveRefreshPending is true (async init still in progress), it tracks the evolving form state as the new clean baseline and resets the timeout, deferring finalization until things stop changing.