### PR TITLE
Pooja | Hive-116894 | Templatized text and on hold status for future orders

### DIFF
--- a/micro-frontends/src/next-ui/Components/ViewOrders/OrderItem.spec.jsx
+++ b/micro-frontends/src/next-ui/Components/ViewOrders/OrderItem.spec.jsx
@@ -101,4 +101,9 @@ it("should display Acknowledged for REQUESTED orderStatus", () => {
         render(<OrderItemContainer {...mockProps} orderStatus="COMPLETED" />);
         expect(screen.getByText("Completed")).toBeTruthy();
     });
+
+    it("should display On Hold for ONHOLD orderStatus", () => {
+        render(<OrderItemContainer {...mockProps} orderStatus="ONHOLD" />);
+        expect(screen.getByText("On Hold")).toBeTruthy();
+    });
 });

--- a/micro-frontends/src/next-ui/constants.js
+++ b/micro-frontends/src/next-ui/constants.js
@@ -48,6 +48,7 @@ export const FHIR_TASK_STATUS_TO_UI_STATUS = {
     DRAFT: 'New',
     REQUESTED: 'Acknowledged',
     ACCEPTED: 'In Progress',
+    ONHOLD: 'On Hold',
     COMPLETED: 'Completed',
 };
 export const FORM_COMMENT = "FORM_COMMENT";

--- a/ui/app/clinical/consultation/views/orderNotes.html
+++ b/ui/app/clinical/consultation/views/orderNotes.html
@@ -3,7 +3,7 @@
 
     <textarea ng-model="$parent.orderNoteText" focus-on="true" rows="4" ng-disabled="ngDialogData.uuid">{{ngDialogData.previousNote}}</textarea>
     <button ng-click="appendPrintNotes(ngDialogData)" class="fl btn-group" ng-show="isPrintShown(ngDialogData.uuid)">{{ 'CLINICAL_ORDER_RADIOLOGY_NEED_PRINT_BUTTON' | translate}}</button>
-    <div style="width: 80%">
+    <div class="order-notes-buttons-container">
         <div ng-repeat=" note in noteOptions">
             <button ng-click="appendNotes(ngDialogData, note.translationKey)" ng-show="shouldShowNoteOptions(ngDialogData.uuid, note.label)" class="fl btn-group order-notes-button">{{note.label}}</button>
         </div>

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -403,6 +403,7 @@
   "PRE_OP": "Pre-operative X-ray for diagnostic or planning purposes",
   "POST_OP": "Post-operative X-ray for assessing healing or implant position",
   "MONITORING": "Monitoring of progress for alignment / comparative purposes",
+  "FUTURE_ORDER": "This order is intended for a follow up visit (Future Order)",
   "FROM_CLINIC": "Request from clinic",
   "FROM_WARD": "Request from ward",
   "HIGH_RISK": "High Risk",

--- a/ui/app/styles/clinical/_orders.scss
+++ b/ui/app/styles/clinical/_orders.scss
@@ -521,9 +521,15 @@
         border-left: #ddd 1px solid !important;
     }
 }
+.order-notes-buttons-container {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+}
+
 .order-notes-button{
     margin-right: 2px;
-    width: 115px
+    width: 125px
 }
 
 .order-note{


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=JWrtXb62KiYMqeg73

Changes:
The system must include a new templatized text option titled "Future Order" within the order notes pop-up window.
