### PR TITLE
Pooja | Hive-117176 | Feedback - Show icon to show a form has data/ unsaved data

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -113,6 +113,7 @@ angular.module('bahmni.clinical')
                         });
                         if (matchingTemplate && (!matchingTemplate.observations || matchingTemplate.observations.length === 0)) {
                             matchingTemplate.observations = [stripObservationFlags(draftObs)];
+                            matchingTemplate.isDraftIndicator = true;
                         }
                     });
                     var form2DraftObs = _.filter(parsedDraftObs, function (draftObs) {
@@ -128,6 +129,7 @@ angular.module('bahmni.clinical')
                                     obsForm.observations.push(obs);
                                 });
                                 obsForm.isOpen = true;
+                                obsForm.isDraftIndicator = true;
                             }
                         });
                     }
@@ -396,12 +398,46 @@ angular.module('bahmni.clinical')
 
             var dirtyTrackingState = {
                 cleanState: null,
+                templateCleanStates: {},
                 initialized: false,
                 watchDeregister: null,
                 postSaveRefreshPending: false,
                 postSaveRefreshTimeout: null,
                 form2ListenerState: null,
                 isSaving: false
+            };
+
+            var getTemplateKey = function (template) {
+                return template.uuid || template.formUuid || template.label;
+            };
+
+            var captureTemplateCleanStates = function () {
+                dirtyTrackingState.templateCleanStates = {};
+                _.each($scope.consultation.selectedObsTemplate, function (template) {
+                    dirtyTrackingState.templateCleanStates[getTemplateKey(template)] =
+                        formDirtyStateService.getObsValuesForTemplate(template);
+                });
+            };
+
+            var updateTemplateDirtyIndicators = function () {
+                _.each($scope.consultation.selectedObsTemplate, function (template) {
+                    if (template.isDraftIndicator) { return; }
+                    var key = getTemplateKey(template);
+                    if (dirtyTrackingState.templateCleanStates[key] === undefined) {
+                        dirtyTrackingState.templateCleanStates[key] =
+                            formDirtyStateService.getObsValuesForTemplate(template);
+                    }
+                    var currentVal = formDirtyStateService.getObsValuesForTemplate(template);
+                    if (currentVal !== dirtyTrackingState.templateCleanStates[key]) {
+                        template.isDraftIndicator = true;
+                    }
+                });
+            };
+
+            var clearAllDraftIndicators = function () {
+                _.each($scope.allTemplates, function (template) {
+                    template.isDraftIndicator = false;
+                });
             };
 
             var clearDraftStatus = function (preserveCleanState) {
@@ -423,10 +459,12 @@ angular.module('bahmni.clinical')
                 dirtyTrackingState.initialized = true;
                 if ($scope.consultation._draftCleanState !== undefined) {
                     dirtyTrackingState.cleanState = $scope.consultation._draftCleanState;
+                    captureTemplateCleanStates();
                     var currentState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                     $scope.formDraft.isDirty = currentState !== dirtyTrackingState.cleanState;
                 } else {
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                    captureTemplateCleanStates();
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
                     dirtyTrackingState.postSaveRefreshPending = true;
                     if (dirtyTrackingState.postSaveRefreshTimeout) {
@@ -439,6 +477,7 @@ angular.module('bahmni.clinical')
                         }
                         var partialRefreshState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                         dirtyTrackingState.cleanState = partialRefreshState;
+                        captureTemplateCleanStates();
                         $scope.consultation._draftCleanState = partialRefreshState;
                         $scope.formDraft.isDirty = false;
                         dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
@@ -448,6 +487,7 @@ angular.module('bahmni.clinical')
                             }
                             var settledCleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                             dirtyTrackingState.cleanState = settledCleanState;
+                            captureTemplateCleanStates();
                             $scope.consultation._draftCleanState = settledCleanState;
                             $scope.formDraft.isDirty = false;
                             dirtyTrackingState.postSaveRefreshPending = false;
@@ -462,6 +502,7 @@ angular.module('bahmni.clinical')
                         if (newVal !== oldVal) {
                             if (dirtyTrackingState.postSaveRefreshPending) {
                                 dirtyTrackingState.cleanState = newVal;
+                                captureTemplateCleanStates();
                                 $scope.consultation._draftCleanState = newVal;
                                 $scope.formDraft.isDirty = false;
                                 if (dirtyTrackingState.postSaveRefreshTimeout) {
@@ -477,6 +518,7 @@ angular.module('bahmni.clinical')
                             if ($scope.formDraft.isDirty) {
                                 $state.dirtyConsultationForm = true;
                             }
+                            updateTemplateDirtyIndicators();
                         }
                     }
                 );
@@ -522,6 +564,7 @@ angular.module('bahmni.clinical')
                     $scope.formDraft.isDirty = false;
                     $scope.formDraft.hasDrafts = true;
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                    captureTemplateCleanStates();
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
                     dirtyTrackingState.postSaveRefreshPending = true;
                     if (dirtyTrackingState.postSaveRefreshTimeout) {
@@ -529,6 +572,7 @@ angular.module('bahmni.clinical')
                     }
                     dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
                         dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                        captureTemplateCleanStates();
                         $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
                         $scope.formDraft.isDirty = false;
                         dirtyTrackingState.postSaveRefreshPending = false;
@@ -635,6 +679,9 @@ angular.module('bahmni.clinical')
                     $scope.formDraft.statusError = true;
                 } else {
                     $scope.formDraft.isDraftResumed = true;
+                    _.each(result.updatedTemplates, function (template) {
+                        template.isDraftIndicator = true;
+                    });
                 }
             };
 
@@ -646,7 +693,9 @@ angular.module('bahmni.clinical')
                     $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
                 }
                 dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                    clearAllDraftIndicators();
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                    captureTemplateCleanStates();
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
                     $scope.formDraft.isDirty = false;
                     dirtyTrackingState.postSaveRefreshPending = false;
@@ -667,7 +716,9 @@ angular.module('bahmni.clinical')
                     $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);
                 }
                 dirtyTrackingState.postSaveRefreshTimeout = $timeout(function () {
+                    clearAllDraftIndicators();
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                    captureTemplateCleanStates();
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
                     $scope.formDraft.isDirty = false;
                     dirtyTrackingState.postSaveRefreshPending = false;

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -398,7 +398,7 @@ angular.module('bahmni.clinical')
 
             var dirtyTrackingState = {
                 cleanState: null,
-                templateCleanStates: {},
+                templateCleanStates: new WeakMap(),
                 initialized: false,
                 watchDeregister: null,
                 postSaveRefreshPending: false,
@@ -407,28 +407,22 @@ angular.module('bahmni.clinical')
                 isSaving: false
             };
 
-            var getTemplateKey = function (template) {
-                return template.uuid || template.formUuid || template.label;
-            };
-
             var captureTemplateCleanStates = function () {
-                dirtyTrackingState.templateCleanStates = {};
+                dirtyTrackingState.templateCleanStates = new WeakMap();
                 _.each($scope.consultation.selectedObsTemplate, function (template) {
-                    dirtyTrackingState.templateCleanStates[getTemplateKey(template)] =
-                        formDirtyStateService.getObsValuesForTemplate(template);
+                    dirtyTrackingState.templateCleanStates.set(template,
+                        formDirtyStateService.getObsValuesForTemplate(template));
                 });
             };
 
             var updateTemplateDirtyIndicators = function () {
                 _.each($scope.consultation.selectedObsTemplate, function (template) {
                     if (template.isDraftIndicator) { return; }
-                    var key = getTemplateKey(template);
-                    if (dirtyTrackingState.templateCleanStates[key] === undefined) {
-                        dirtyTrackingState.templateCleanStates[key] =
-                            formDirtyStateService.getObsValuesForTemplate(template);
-                    }
                     var currentVal = formDirtyStateService.getObsValuesForTemplate(template);
-                    if (currentVal !== dirtyTrackingState.templateCleanStates[key]) {
+                    if (!dirtyTrackingState.templateCleanStates.has(template)) {
+                        dirtyTrackingState.templateCleanStates.set(template, currentVal);
+                    }
+                    if (currentVal !== dirtyTrackingState.templateCleanStates.get(template)) {
                         template.isDraftIndicator = true;
                     }
                 });

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -113,7 +113,7 @@ angular.module('bahmni.clinical')
                         });
                         if (matchingTemplate && (!matchingTemplate.observations || matchingTemplate.observations.length === 0)) {
                             matchingTemplate.observations = [stripObservationFlags(draftObs)];
-                            matchingTemplate.isDraftIndicator = true;
+                            matchingTemplate.hasUnsavedFormObservations = true;
                         }
                     });
                     var form2DraftObs = _.filter(parsedDraftObs, function (draftObs) {
@@ -129,7 +129,7 @@ angular.module('bahmni.clinical')
                                     obsForm.observations.push(obs);
                                 });
                                 obsForm.isOpen = true;
-                                obsForm.isDraftIndicator = true;
+                                obsForm.hasUnsavedFormObservations = true;
                             }
                         });
                     }
@@ -417,20 +417,20 @@ angular.module('bahmni.clinical')
 
             var updateTemplateDirtyIndicators = function () {
                 _.each($scope.consultation.selectedObsTemplate, function (template) {
-                    if (template.isDraftIndicator) { return; }
+                    if (template.hasUnsavedFormObservations) { return; }
                     var currentVal = formDirtyStateService.getObsValuesForTemplate(template);
                     if (!dirtyTrackingState.templateCleanStates.has(template)) {
                         dirtyTrackingState.templateCleanStates.set(template, currentVal);
                     }
                     if (currentVal !== dirtyTrackingState.templateCleanStates.get(template)) {
-                        template.isDraftIndicator = true;
+                        template.hasUnsavedFormObservations = true;
                     }
                 });
             };
 
             var clearAllDraftIndicators = function () {
                 _.each($scope.allTemplates, function (template) {
-                    template.isDraftIndicator = false;
+                    template.hasUnsavedFormObservations = false;
                 });
             };
 
@@ -674,7 +674,7 @@ angular.module('bahmni.clinical')
                 } else {
                     $scope.formDraft.isDraftResumed = true;
                     _.each(result.updatedTemplates, function (template) {
-                        template.isDraftIndicator = true;
+                        template.hasUnsavedFormObservations = true;
                     });
                 }
             };

--- a/ui/app/clinical/consultation/services/formDirtyStateService.js
+++ b/ui/app/clinical/consultation/services/formDirtyStateService.js
@@ -50,6 +50,15 @@ angular.module('bahmni.clinical')
             return template.observations || [];
         };
 
+        var getObsValuesForTemplate = function (template) {
+            var values = [];
+            var observations = getTemplateObservationsForDirtyTracking(template);
+            _.each(observations, function (obs) {
+                collectObsValues(obs, values);
+            });
+            return angular.toJson(values);
+        };
+
         /**
          * Returns a JSON string representing all observation values across all templates.
          * This is the "clean state" baseline for dirty tracking.
@@ -187,21 +196,27 @@ angular.module('bahmni.clinical')
                     return {success: false, error: 'Missing data'};
                 }
 
+                var updatedTemplates = [];
                 _.each(draftData, function (draftObs) {
                     _.each(selectedObsTemplates, function (template) {
                         var templateObs = getTemplateObservationsForDirtyTracking(template);
                         if (templateObs && templateObs.length > 0) {
+                            var templateUpdated = false;
                             _.each(templateObs, function (templateMember) {
                                 if (templateMember.concept && draftObs.concept &&
                                     templateMember.concept.uuid === draftObs.concept.uuid) {
                                     populateObservationValues(templateMember, draftObs);
+                                    templateUpdated = true;
                                 }
                             });
+                            if (templateUpdated && updatedTemplates.indexOf(template) === -1) {
+                                updatedTemplates.push(template);
+                            }
                         }
                     });
                 });
 
-                return {success: true};
+                return {success: true, updatedTemplates: updatedTemplates};
             } catch (e) {
                 return {success: false, error: e.message};
             }
@@ -210,6 +225,7 @@ angular.module('bahmni.clinical')
         return {
             collectObsValues: collectObsValues,
             getObsValues: getObsValues,
+            getObsValuesForTemplate: getObsValuesForTemplate,
             getTemplateObservationsForDirtyTracking: getTemplateObservationsForDirtyTracking,
             syncForm2Observations: syncForm2Observations,
             registerForm2SyncListeners: registerForm2SyncListeners,

--- a/ui/app/common/concept-set/views/conceptSetGroup.html
+++ b/ui/app/common/concept-set/views/conceptSetGroup.html
@@ -10,7 +10,7 @@
             <div class="multi-select-lab-tests">
                 <ul>
                     <li ng-repeat="conceptSet in allTemplates track by $index"
-                        ng-if="conceptSet.isAvailable(context) && (conceptSet.isAdded || conceptSet.alwaysShow)"  ng-class="openActiveForm(conceptSet)">
+                        ng-if="conceptSet.isAvailable(context) && (conceptSet.isAdded || conceptSet.alwaysShow)"  ng-class="[openActiveForm(conceptSet), {'has-draft-indicator': conceptSet.isDraftIndicator}]">
                         <a ng-click="showLeftPanelConceptSet(conceptSet)">
                             <span class="concept-set-name" ng-class="{'concept-set-name-extra':conceptSet.isValid === false}">
                                 {{conceptSet.label}}

--- a/ui/app/common/concept-set/views/conceptSetGroup.html
+++ b/ui/app/common/concept-set/views/conceptSetGroup.html
@@ -10,7 +10,7 @@
             <div class="multi-select-lab-tests">
                 <ul>
                     <li ng-repeat="conceptSet in allTemplates track by $index"
-                        ng-if="conceptSet.isAvailable(context) && (conceptSet.isAdded || conceptSet.alwaysShow)"  ng-class="[openActiveForm(conceptSet), {'has-draft-indicator': conceptSet.isDraftIndicator}]">
+                        ng-if="conceptSet.isAvailable(context) && (conceptSet.isAdded || conceptSet.alwaysShow)"  ng-class="[openActiveForm(conceptSet), {'has-unsaved-form-observations': conceptSet.hasUnsavedFormObservations}]">
                         <a ng-click="showLeftPanelConceptSet(conceptSet)">
                             <span class="concept-set-name" ng-class="{'concept-set-name-extra':conceptSet.isValid === false}">
                                 {{conceptSet.label}}

--- a/ui/app/styles/clinical/_observations.scss
+++ b/ui/app/styles/clinical/_observations.scss
@@ -728,7 +728,7 @@ concept-set {
           }
 
         }
-        &.has-draft-indicator {
+        &.has-unsaved-form-observations {
           border-left: 3px solid #FFA500;
         }
       }

--- a/ui/app/styles/clinical/_observations.scss
+++ b/ui/app/styles/clinical/_observations.scss
@@ -728,6 +728,9 @@ concept-set {
           }
 
         }
+        &.has-draft-indicator {
+          border-left: 3px solid #FFA500;
+        }
       }
     }
   }

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -2457,22 +2457,18 @@ describe('ConceptSetPageController', function () {
                 var observationValue;
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
-                scope.consultation.selectedObsTemplate = [{
-                    uuid: conceptUuid,
-                    component: {
-                        getValue: function () {
-                            return {observations: [{value: observationValue}]};
-                        }
-                    },
-                    observations: []
-                }];
+                // Add component.getValue to the existing template object (same reference captured by WeakMap at init)
+                var template = _.find(scope.consultation.selectedObsTemplate, function (t) { return t.uuid === conceptUuid; });
+                template.component = {
+                    getValue: function () { return {observations: [{value: observationValue}]}; }
+                };
 
                 scope.$digest();
-                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBeFalsy();
+                expect(template.isDraftIndicator).toBeFalsy();
 
                 observationValue = 'some-value';
                 scope.$digest();
-                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(true);
+                expect(template.isDraftIndicator).toBe(true);
             });
 
             it('should not set isDraftIndicator on templates that have not changed', function () {
@@ -2485,25 +2481,18 @@ describe('ConceptSetPageController', function () {
                 var formAValue;
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
-                scope.consultation.selectedObsTemplate = [
-                    {
-                        uuid: 'uuid-a',
-                        component: {getValue: function () { return {observations: [{value: formAValue}]}; }},
-                        observations: []
-                    },
-                    {
-                        uuid: 'uuid-b',
-                        observations: [{value: null}]
-                    }
-                ];
+                // Add component.getValue to existing template objects (same references captured by WeakMap at init)
+                var templateA = _.find(scope.consultation.selectedObsTemplate, function (t) { return t.uuid === 'uuid-a'; });
+                var templateB = _.find(scope.consultation.selectedObsTemplate, function (t) { return t.uuid === 'uuid-b'; });
+                templateA.component = {getValue: function () { return {observations: [{value: formAValue}]}; }};
 
                 scope.$digest();
 
                 formAValue = 'changed';
                 scope.$digest();
 
-                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(true);
-                expect(scope.consultation.selectedObsTemplate[1].isDraftIndicator).toBeFalsy();
+                expect(templateA.isDraftIndicator).toBe(true);
+                expect(templateB.isDraftIndicator).toBeFalsy();
             });
 
             it('should set isDraftIndicator on concept-set template when draft is resumed on direct navigation', function () {

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -2437,5 +2437,190 @@ describe('ConceptSetPageController', function () {
                 expect(removeEventListenerSpy).toHaveBeenCalledWith('click', jasmine.any(Function), true);
             });
         });
+
+        describe('Draft Indicator', function () {
+            var timeoutMock;
+
+            beforeEach(function () {
+                timeoutMock = function (callback, delay) {
+                    if (delay === 0) { callback(); }
+                    return {$$timeoutId: delay};
+                };
+                timeoutMock.cancel = jasmine.createSpy('cancel');
+            });
+
+            it('should set isDraftIndicator on a template when its observations change', function () {
+                var conceptUuid = 'concept-uuid-indicator';
+                mockConceptSetService({results: [{setMembers: [{name: {name: 'Test Form'}, uuid: conceptUuid}]}]});
+                mockformService({});
+
+                var observationValue;
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                scope.consultation.selectedObsTemplate = [{
+                    uuid: conceptUuid,
+                    component: {
+                        getValue: function () {
+                            return {observations: [{value: observationValue}]};
+                        }
+                    },
+                    observations: []
+                }];
+
+                scope.$digest();
+                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBeFalsy();
+
+                observationValue = 'some-value';
+                scope.$digest();
+                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(true);
+            });
+
+            it('should not set isDraftIndicator on templates that have not changed', function () {
+                mockConceptSetService({results: [{setMembers: [
+                    {name: {name: 'Form A'}, uuid: 'uuid-a'},
+                    {name: {name: 'Form B'}, uuid: 'uuid-b'}
+                ]}]});
+                mockformService({});
+
+                var formAValue;
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                scope.consultation.selectedObsTemplate = [
+                    {
+                        uuid: 'uuid-a',
+                        component: {getValue: function () { return {observations: [{value: formAValue}]}; }},
+                        observations: []
+                    },
+                    {
+                        uuid: 'uuid-b',
+                        observations: [{value: null}]
+                    }
+                ];
+
+                scope.$digest();
+
+                formAValue = 'changed';
+                scope.$digest();
+
+                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(true);
+                expect(scope.consultation.selectedObsTemplate[1].isDraftIndicator).toBeFalsy();
+            });
+
+            it('should set isDraftIndicator on concept-set template when draft is resumed on direct navigation', function () {
+                var conceptUuid = 'concept-uuid-resume';
+                mockConceptSetService({results: [{setMembers: [{name: {name: 'Resume Form'}, uuid: conceptUuid}]}]});
+                mockformService({});
+
+                var appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
+                appDescriptor.getConfigValue.and.returnValue(true);
+                appService.getAppDescriptor.and.returnValue(appDescriptor);
+
+                scope.patient = {uuid: 'patient-uuid'};
+                rootScope.currentProvider = {uuid: 'provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+
+                var draftObs = [{concept: {uuid: conceptUuid}, value: 'resumed-value', groupMembers: []}];
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: 'draft-uuid', markedAsSaved: false, formData: angular.toJson(draftObs)}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var template = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(template.isDraftIndicator).toBe(true);
+            });
+
+            it('should set isDraftIndicator on Form2 template when draft is resumed', function () {
+                mockConceptSetService({results: [{setMembers: [{name: {name: 'Obs Form'}, uuid: 'obs-uuid'}]}]});
+                var form2Data = [{
+                    name: 'Fall Risk Assessment', uuid: 'fall-risk-uuid', version: '1',
+                    published: true, id: null, resources: null, nameTranslation: null, privileges: []
+                }];
+                mockformService(form2Data);
+
+                var appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
+                appDescriptor.getConfigValue.and.returnValue(true);
+                appService.getAppDescriptor.and.returnValue(appDescriptor);
+
+                scope.patient = {uuid: 'patient-uuid'};
+                rootScope.currentProvider = {uuid: 'provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var draftObs = [{
+                    concept: {uuid: 'field-uuid'}, value: 'val',
+                    formNamespace: 'Bahmni', formFieldPath: 'Fall Risk Assessment.1/1-0'
+                }];
+                formDraftService.getDraft.and.returnValue({
+                    then: function (success) {
+                        success({data: {uuid: 'draft-uuid', markedAsSaved: false, formData: angular.toJson(draftObs)}});
+                        return {catch: function () { return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var obsForm = scope.consultation.observationForms[0];
+                expect(obsForm.isDraftIndicator).toBe(true);
+            });
+
+            it('should clear isDraftIndicator on all templates when encounter is saved', function () {
+                var conceptUuid = 'concept-uuid-save';
+                mockConceptSetService({results: [{setMembers: [{name: {name: 'Save Form'}, uuid: conceptUuid}]}]});
+                mockformService({});
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], isDraftIndicator: true}];
+                scope.allTemplates = scope.consultation.selectedObsTemplate;
+
+                rootScope.$broadcast('event:save-successful');
+
+                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(false);
+            });
+
+            it('should clear isDraftIndicator on all templates when post-save handler fires', function () {
+                var conceptUuid = 'concept-uuid-postsave';
+                mockConceptSetService({results: [{setMembers: [{name: {name: 'PostSave Form'}, uuid: conceptUuid}]}]});
+                mockformService({});
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], isDraftIndicator: true}];
+                scope.allTemplates = scope.consultation.selectedObsTemplate;
+
+                scope.consultation.postSaveHandler.fire();
+
+                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(false);
+            });
+
+            it('should keep isDraftIndicator after save as draft', function () {
+                var conceptUuid = 'concept-uuid-draft-save';
+                mockConceptSetService({results: [{setMembers: [{name: {name: 'Draft Form'}, uuid: conceptUuid}]}]});
+                mockformService({});
+
+                var filterMock = function () { return function () { return 'mocked-time'; }; };
+                var saveDraftResponse = {data: {timestamp: Date.now()}};
+                formDraftService.saveDraft.and.returnValue({
+                    then: function (success) {
+                        success(saveDraftResponse);
+                        return {finally: function (cb) { cb(); return this; }};
+                    }
+                });
+
+                createControllerWithTimeoutAndFilter(timeoutMock, filterMock);
+
+                scope.visitHistory = {activeVisit: {uuid: 'visit-uuid'}};
+                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], isDraftIndicator: true}];
+
+                scope.saveAsDraft();
+
+                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(true);
+            });
+        });
     });
 });
+

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -2449,7 +2449,7 @@ describe('ConceptSetPageController', function () {
                 timeoutMock.cancel = jasmine.createSpy('cancel');
             });
 
-            it('should set isDraftIndicator on a template when its observations change', function () {
+            it('should set hasUnsavedFormObservations on a template when its observations change', function () {
                 var conceptUuid = 'concept-uuid-indicator';
                 mockConceptSetService({results: [{setMembers: [{name: {name: 'Test Form'}, uuid: conceptUuid}]}]});
                 mockformService({});
@@ -2464,14 +2464,14 @@ describe('ConceptSetPageController', function () {
                 };
 
                 scope.$digest();
-                expect(template.isDraftIndicator).toBeFalsy();
+                expect(template.hasUnsavedFormObservations).toBeFalsy();
 
                 observationValue = 'some-value';
                 scope.$digest();
-                expect(template.isDraftIndicator).toBe(true);
+                expect(template.hasUnsavedFormObservations).toBe(true);
             });
 
-            it('should not set isDraftIndicator on templates that have not changed', function () {
+            it('should not set hasUnsavedFormObservations on templates that have not changed', function () {
                 mockConceptSetService({results: [{setMembers: [
                     {name: {name: 'Form A'}, uuid: 'uuid-a'},
                     {name: {name: 'Form B'}, uuid: 'uuid-b'}
@@ -2491,11 +2491,11 @@ describe('ConceptSetPageController', function () {
                 formAValue = 'changed';
                 scope.$digest();
 
-                expect(templateA.isDraftIndicator).toBe(true);
-                expect(templateB.isDraftIndicator).toBeFalsy();
+                expect(templateA.hasUnsavedFormObservations).toBe(true);
+                expect(templateB.hasUnsavedFormObservations).toBeFalsy();
             });
 
-            it('should set isDraftIndicator on concept-set template when draft is resumed on direct navigation', function () {
+            it('should set hasUnsavedFormObservations on concept-set template when draft is resumed on direct navigation', function () {
                 var conceptUuid = 'concept-uuid-resume';
                 mockConceptSetService({results: [{setMembers: [{name: {name: 'Resume Form'}, uuid: conceptUuid}]}]});
                 mockformService({});
@@ -2519,10 +2519,10 @@ describe('ConceptSetPageController', function () {
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
                 var template = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
-                expect(template.isDraftIndicator).toBe(true);
+                expect(template.hasUnsavedFormObservations).toBe(true);
             });
 
-            it('should set isDraftIndicator on Form2 template when draft is resumed', function () {
+            it('should set hasUnsavedFormObservations on Form2 template when draft is resumed', function () {
                 mockConceptSetService({results: [{setMembers: [{name: {name: 'Obs Form'}, uuid: 'obs-uuid'}]}]});
                 var form2Data = [{
                     name: 'Fall Risk Assessment', uuid: 'fall-risk-uuid', version: '1',
@@ -2553,40 +2553,40 @@ describe('ConceptSetPageController', function () {
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
                 var obsForm = scope.consultation.observationForms[0];
-                expect(obsForm.isDraftIndicator).toBe(true);
+                expect(obsForm.hasUnsavedFormObservations).toBe(true);
             });
 
-            it('should clear isDraftIndicator on all templates when encounter is saved', function () {
+            it('should clear hasUnsavedFormObservations on all templates when encounter is saved', function () {
                 var conceptUuid = 'concept-uuid-save';
                 mockConceptSetService({results: [{setMembers: [{name: {name: 'Save Form'}, uuid: conceptUuid}]}]});
                 mockformService({});
 
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
-                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], isDraftIndicator: true}];
+                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], hasUnsavedFormObservations: true}];
                 scope.allTemplates = scope.consultation.selectedObsTemplate;
 
                 rootScope.$broadcast('event:save-successful');
 
-                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(false);
+                expect(scope.consultation.selectedObsTemplate[0].hasUnsavedFormObservations).toBe(false);
             });
 
-            it('should clear isDraftIndicator on all templates when post-save handler fires', function () {
+            it('should clear hasUnsavedFormObservations on all templates when post-save handler fires', function () {
                 var conceptUuid = 'concept-uuid-postsave';
                 mockConceptSetService({results: [{setMembers: [{name: {name: 'PostSave Form'}, uuid: conceptUuid}]}]});
                 mockformService({});
 
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
-                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], isDraftIndicator: true}];
+                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], hasUnsavedFormObservations: true}];
                 scope.allTemplates = scope.consultation.selectedObsTemplate;
 
                 scope.consultation.postSaveHandler.fire();
 
-                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(false);
+                expect(scope.consultation.selectedObsTemplate[0].hasUnsavedFormObservations).toBe(false);
             });
 
-            it('should keep isDraftIndicator after save as draft', function () {
+            it('should keep hasUnsavedFormObservations after save as draft', function () {
                 var conceptUuid = 'concept-uuid-draft-save';
                 mockConceptSetService({results: [{setMembers: [{name: {name: 'Draft Form'}, uuid: conceptUuid}]}]});
                 mockformService({});
@@ -2603,11 +2603,11 @@ describe('ConceptSetPageController', function () {
                 createControllerWithTimeoutAndFilter(timeoutMock, filterMock);
 
                 scope.visitHistory = {activeVisit: {uuid: 'visit-uuid'}};
-                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], isDraftIndicator: true}];
+                scope.consultation.selectedObsTemplate = [{uuid: conceptUuid, observations: [], hasUnsavedFormObservations: true}];
 
                 scope.saveAsDraft();
 
-                expect(scope.consultation.selectedObsTemplate[0].isDraftIndicator).toBe(true);
+                expect(scope.consultation.selectedObsTemplate[0].hasUnsavedFormObservations).toBe(true);
             });
         });
     });

--- a/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
+++ b/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
@@ -118,6 +118,43 @@ describe('formDirtyStateService', function () {
         });
     });
 
+    describe('getObsValuesForTemplate', function () {
+        it('should return JSON string of observation values for a single template', function () {
+            var template = {
+                observations: [{value: 'obs1'}, {value: 'obs2'}]
+            };
+            var result = formDirtyStateService.getObsValuesForTemplate(template);
+            var parsed = JSON.parse(result);
+            expect(parsed).toEqual(['obs1', 'obs2']);
+        });
+
+        it('should return empty JSON array for a template with no observations', function () {
+            var template = {observations: []};
+            var result = formDirtyStateService.getObsValuesForTemplate(template);
+            expect(result).toBe('[]');
+        });
+
+        it('should use component.getValue for Form2 templates', function () {
+            var mockComponent = {
+                getValue: jasmine.createSpy('getValue').and.returnValue({
+                    observations: [{value: 'form2-val'}]
+                })
+            };
+            var template = {component: mockComponent, observations: []};
+            var result = formDirtyStateService.getObsValuesForTemplate(template);
+            var parsed = JSON.parse(result);
+            expect(parsed).toEqual(['form2-val']);
+        });
+
+        it('should return different values for two templates with different data', function () {
+            var template1 = {observations: [{value: 'val1'}]};
+            var template2 = {observations: [{value: 'val2'}]};
+            var result1 = formDirtyStateService.getObsValuesForTemplate(template1);
+            var result2 = formDirtyStateService.getObsValuesForTemplate(template2);
+            expect(result1).not.toEqual(result2);
+        });
+    });
+
     describe('getObsValues', function () {
         it('should return JSON string of all observation values', function () {
             var templates = [
@@ -414,6 +451,29 @@ describe('formDirtyStateService', function () {
             expect(result.success).toBe(true);
             expect(templates[0].observations[0].value).toBe('draft1');
             expect(templates[0].observations[0].comment).toBe('test');
+        });
+
+        it('should return updatedTemplates with templates that received draft data', function () {
+            var template1 = {observations: [{concept: {uuid: 'uuid-1'}, value: 'old'}]};
+            var template2 = {observations: [{concept: {uuid: 'uuid-2'}, value: 'old'}]};
+            var templates = [template1, template2];
+            var draftData = JSON.stringify([{concept: {uuid: 'uuid-1'}, value: 'new'}]);
+
+            var result = formDirtyStateService.populateFormWithDraftData(draftData, templates);
+
+            expect(result.success).toBe(true);
+            expect(result.updatedTemplates.length).toBe(1);
+            expect(result.updatedTemplates[0]).toBe(template1);
+        });
+
+        it('should return empty updatedTemplates when no obs matched draft data', function () {
+            var templates = [{observations: [{concept: {uuid: 'uuid-X'}, value: 'old'}]}];
+            var draftData = JSON.stringify([{concept: {uuid: 'uuid-not-found'}, value: 'new'}]);
+
+            var result = formDirtyStateService.populateFormWithDraftData(draftData, templates);
+
+            expect(result.success).toBe(true);
+            expect(result.updatedTemplates.length).toBe(0);
         });
 
         it('should return success: false for invalid JSON', function () {


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=CqZAmdMQv6TWvXenv

Claude PR Review plugin major issue and fix:
- `getTemplateKey` produces key collisions for `allowAddMore` cloned templates

**Category**: Bugs
**File**: ui/app/clinical/consultation/controllers/conceptSetPageController.js
**Lines**: 410-412

**Issue**:
`getTemplateKey` returns `template.uuid || template.formUuid || template.label`. When a user adds multiple instances of an `allowAddMore` template via `clone()`, each clone gets the same `uuid` as the original (the constructor uses `conceptSet.uuid`). All clones share the same key in `templateCleanStates`, so `captureTemplateCleanStates` silently overwrites earlier clones' baselines with the last one's value. This means dirty tracking for cloned instances will compare against the wrong baseline — either missing real changes or false-flagging unchanged instances.

**Evidence**:
`conceptSetSection.js` — `clone()` creates a new `ConceptSetSection` with the same `conceptSet` argument, inheriting the same `uuid`. The `$scope.clone` function at conceptSetGroup.js:86 confirms this pattern.

**Suggested Fix**:
Append an instance discriminator to the key. Options:
- Use `template.id` (which is `"concept-set-" + uuid`) combined with the template's array index
- Use a `WeakMap` keyed on the template object reference, eliminating string-key collisions entirely

Fix: WeakMap has been used

Screenshot of the draft indicator
<img width="1554" height="949" alt="image" src="https://github.com/user-attachments/assets/e5e4a463-f2b1-4426-86e4-8c98c59dcdc6" />

