### PR TITLE
Banti | fix issue - fetch latest lmp date obs to calculate the days since LMP

### DIFF
--- a/ui/app/common/patient/services/patientService.js
+++ b/ui/app/common/patient/services/patientService.js
@@ -69,7 +69,7 @@ angular.module('bahmni.common.patient')
             if (!patientUuid || !angular.isString(patientUuid) || !conceptName) {
                 return $q.when(null);
             }
-            var url = Bahmni.Common.Constants.openmrsObsUrl + "?patient=" + patientUuid + "&concept=" + encodeURIComponent(conceptName) + "&limit=1";
+            var url = Bahmni.Common.Constants.openmrsObsUrl + "?patient=" + patientUuid + "&concept=" + encodeURIComponent(conceptName) + "&v=custom:(uuid,value,display,auditInfo:(dateCreated))";
 
             return $http.get(url, {
                 withCredentials: true
@@ -78,7 +78,11 @@ angular.module('bahmni.common.patient')
                     return null;
                 }
 
-                var obs = response.data.results[0];
+                var sortedObs = response.data.results.sort(function (a, b) {
+                    return new Date(b.auditInfo.dateCreated) - new Date(a.auditInfo.dateCreated);
+                });
+
+                var obs = sortedObs[0];
                 var lmpDateStr = obs.value || (obs.display && obs.display.match(/(\d{4}-\d{2}-\d{2})/) || [])[1];
 
                 if (!lmpDateStr) {

--- a/ui/test/unit/common/patient/services/patientService.spec.js
+++ b/ui/test/unit/common/patient/services/patientService.spec.js
@@ -38,16 +38,17 @@ describe('patientService', function () {
     });
 
     describe('getPatientLmpData', function () {
-        it('should fetch and return LMP data successfully', function () {
+        it('should fetch and return LMP data for single obs', function () {
             var patientUuid = 'patient-uuid-123';
             var conceptName = 'LMP Date';
             var lmpResponse = {
                 results: [{
-                    value: '2026-04-10'
+                    value: '2026-04-10',
+                    auditInfo: { dateCreated: '2026-04-10T10:00:00.000+0000' }
                 }]
             };
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-123&concept=LMP%20Date&limit=1/).respond(lmpResponse);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs.*patient=patient-uuid-123&concept=LMP%20Date/).respond(lmpResponse);
 
             patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeTruthy();
@@ -58,12 +59,42 @@ describe('patientService', function () {
             mockBackend.flush();
         });
 
+        it('should return the most recently created obs when multiple obs exist', function () {
+            var patientUuid = 'patient-uuid-multi';
+            var conceptName = 'LMP Date';
+            var lmpResponse = {
+                results: [
+                    {
+                        value: '2026-02-01',
+                        auditInfo: { dateCreated: '2026-06-11T09:23:25.000+0000' }
+                    },
+                    {
+                        value: '2026-05-06',
+                        auditInfo: { dateCreated: '2026-06-11T09:52:20.000+0000' }
+                    },
+                    {
+                        value: '2026-05-01',
+                        auditInfo: { dateCreated: '2026-06-11T09:28:45.000+0000' }
+                    }
+                ]
+            };
+
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs.*patient=patient-uuid-multi&concept=LMP%20Date/).respond(lmpResponse);
+
+            patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
+                expect(data).toBeTruthy();
+                expect(data.lmpDate).toBe('2026-05-06');
+            });
+
+            mockBackend.flush();
+        });
+
         it('should return null when no observations found', function () {
             var patientUuid = 'patient-uuid-456';
             var conceptName = 'LMP Date';
             var emptyResponse = {results: []};
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-456&concept=LMP%20Date&limit=1/).respond(emptyResponse);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs.*patient=patient-uuid-456&concept=LMP%20Date/).respond(emptyResponse);
 
             patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeNull();
@@ -94,11 +125,37 @@ describe('patientService', function () {
             var conceptName = 'LMP Date';
             var responseWithoutValue = {
                 results: [{
-                    value: null
+                    value: null,
+                    auditInfo: { dateCreated: '2026-06-11T09:00:00.000+0000' }
                 }]
             };
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-789&concept=LMP%20Date&limit=1/).respond(responseWithoutValue);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs.*patient=patient-uuid-789&concept=LMP%20Date/).respond(responseWithoutValue);
+
+            patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
+                expect(data).toBeNull();
+            });
+
+            mockBackend.flush();
+        });
+
+        it('should return null when LMP date is in the future', function () {
+            var patientUuid = 'patient-uuid-future';
+            var conceptName = 'LMP Date';
+            var futureDate = new Date();
+            futureDate.setDate(futureDate.getDate() + 5);
+            var futureDateStr = futureDate.getFullYear() + '-' +
+                String(futureDate.getMonth() + 1).padStart(2, '0') + '-' +
+                String(futureDate.getDate()).padStart(2, '0');
+
+            var lmpResponse = {
+                results: [{
+                    value: futureDateStr,
+                    auditInfo: { dateCreated: '2026-06-11T09:00:00.000+0000' }
+                }]
+            };
+
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs.*patient=patient-uuid-future&concept=LMP%20Date/).respond(lmpResponse);
 
             patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeNull();
@@ -111,7 +168,7 @@ describe('patientService', function () {
             var patientUuid = 'patient-uuid-error';
             var conceptName = 'LMP Date';
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-error&concept=LMP%20Date&limit=1/).respond(500, 'Server Error');
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs.*patient=patient-uuid-error&concept=LMP%20Date/).respond(500, 'Server Error');
 
             patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data).toBeNull();
@@ -120,7 +177,7 @@ describe('patientService', function () {
             mockBackend.flush();
         });
 
-        it('should include daysSinceLmp in returned data', function () {
+        it('should include correct daysSinceLmp in returned data', function () {
             var patientUuid = 'patient-uuid-with-days';
             var conceptName = 'LMP Date';
             var thirtyDaysAgo = new Date();
@@ -131,11 +188,12 @@ describe('patientService', function () {
 
             var lmpResponse = {
                 results: [{
-                    value: lmpDateStr
+                    value: lmpDateStr,
+                    auditInfo: { dateCreated: '2026-06-11T09:00:00.000+0000' }
                 }]
             };
 
-            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs\?patient=patient-uuid-with-days&concept=LMP%20Date&limit=1/).respond(lmpResponse);
+            mockBackend.expectGET(/\/openmrs\/ws\/rest\/v1\/obs.*patient=patient-uuid-with-days&concept=LMP%20Date/).respond(lmpResponse);
 
             patientService.getPatientLmpData(patientUuid, conceptName).then(function (data) {
                 expect(data.lmpDate).toBe(lmpDateStr);


### PR DESCRIPTION
 Problem

  The LMP warning banner was showing incorrect/random LMP dates instead of the most recently entered one.

  Root Cause: The API call used limit=1 without any sort order:
  /openmrs/ws/rest/v1/obs?patient=<uuid>&concept=LMP%20Date&limit=1
  - The OpenMRS REST API default sort is obsDatetime ASC (oldest first), so limit=1 was returning the oldest LMP obs, not the latest.
  - Even sorting by obsDatetime would be unreliable because obs_datetime = encounter datetime which never updates when re-saving a form. Multiple edits within the same form all share the same obs_datetime.
  - When a patient enters LMP dates from multiple forms (Nursing Initial Assessment, ENT Triage, Plastics Triage etc.), each form has its own encounter with a different obs_datetime, making ordering by it unpredictable.

  Solution

  - Removed limit=1 to fetch all active LMP obs
  - Replaced v=full with a custom representation v=custom:(uuid,value,display,auditInfo:(dateCreated)) to fetch only required fields
  - Sort by auditInfo.dateCreated DESC on the frontend — dateCreated is set when each obs row is created and reliably reflects the actual time the user last saved the LMP date, regardless of which form it came from

  Changes

  ui/app/common/patient/services/patientService.js
  - Updated getPatientLmpData() to use v=custom:(uuid,value,display,auditInfo:(dateCreated)) instead of limit=1
  - Added sort by auditInfo.dateCreated DESC before selecting the first result
  
  ui/test/unit/common/patient/services/patientService.spec.js
  - Updated URL patterns to match new API call
  - Updated mock responses to include auditInfo.dateCreated
  - Added test case: should return the most recently created obs when multiple obs exist
  - Added test case: should return null when LMP date is in the future