### PR TITLE
Pooja | Bug-116474 | Fix for issue #4

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -51,16 +51,34 @@ angular.module('bahmni.clinical')
                     }));
                 }
             };
+            var clearDraftObsFromTemplates = function () {
+                $rootScope.draftData = null;
+                $rootScope.resumeDraftOnLoad = false;
+                $rootScope.resumeDraftPatientUuid = null;
+                $scope.consultation.selectedObsTemplate = [];
+                _.each($scope.consultation.observationForms, function (form) {
+                    if (form.hasUnsavedFormObservations) {
+                        form.observations = [];
+                        form.hasUnsavedFormObservations = false;
+                    }
+                });
+            };
+
             var loadDraftThenConcat = function () {
                 var patientUuid = $scope.patient ? $scope.patient.uuid : null;
                 var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
-                if ($scope.enableFormDraftFeature && !$rootScope.resumeDraftOnLoad && patientUuid && providerUuid) {
+                if ($scope.enableFormDraftFeature && !$rootScope.resumeDraftOnLoad && patientUuid && providerUuid && $scope.visitHistory && $scope.visitHistory.activeVisit) {
                     var promise = formDraftService.getDraft(patientUuid, providerUuid);
                     promise.then(function (response) {
-                        if (response && response.data && response.data.uuid && !response.data.markedAsSaved) {
+                        var visitClosed = $scope.visitHistory && !$scope.visitHistory.activeVisit;
+                        if (!visitClosed && response && response.data && response.data.uuid && !response.data.markedAsSaved) {
                             $rootScope.draftData = response.data;
+                        } else if (visitClosed) {
+                            clearDraftObsFromTemplates();
                         } else {
                             $rootScope.draftData = null;
+                            $rootScope.resumeDraftOnLoad = false;
+                            $rootScope.resumeDraftPatientUuid = null;
                         }
                         if ($rootScope.draftData && $rootScope.draftData.uuid && !$rootScope.draftData.markedAsSaved) {
                             $rootScope.resumeDraftOnLoad = true;
@@ -71,6 +89,9 @@ angular.module('bahmni.clinical')
                         concatObservationForms();
                     });
                 } else {
+                    if ($scope.visitHistory && !$scope.visitHistory.activeVisit) {
+                        clearDraftObsFromTemplates();
+                    }
                     concatObservationForms();
                 }
             };
@@ -84,6 +105,24 @@ angular.module('bahmni.clinical')
                 var isDraftResumeValid = $rootScope.resumeDraftOnLoad &&
                     $rootScope.draftData &&
                     (!$rootScope.resumeDraftPatientUuid || $rootScope.resumeDraftPatientUuid === currentPatientUuid);
+
+                if (!isDraftResumeValid) {
+                    var hasStaleUnsavedObs = _.some($scope.consultation.selectedObsTemplate, function (t) {
+                        return t.hasUnsavedFormObservations;
+                    }) || _.some($scope.consultation.observationForms, function (f) {
+                        return f.hasUnsavedFormObservations;
+                    });
+                    if (hasStaleUnsavedObs) {
+                        $scope.consultation.selectedObsTemplate = [];
+                        _.each($scope.consultation.observationForms, function (form) {
+                            if (form.hasUnsavedFormObservations) {
+                                form.observations = [];
+                                form.hasUnsavedFormObservations = false;
+                            }
+                        });
+                    }
+                }
+
                 var draftFormData = isDraftResumeValid && $rootScope.draftData.formData ? $rootScope.draftData.formData : null;
 
                 var parsedDraftObs = null;
@@ -618,7 +657,7 @@ angular.module('bahmni.clinical')
                 draftCheckPromise = formDraftService.getDraft(patientUuid, providerUuid);
                 draftCheckPromise.then(
                     function (response) {
-                        if (response.data && response.data.uuid && !response.data.markedAsSaved) {
+                        if (response.data && response.data.uuid && !response.data.markedAsSaved && $scope.visitHistory && $scope.visitHistory.activeVisit) {
                             $scope.formDraft.hasDrafts = true;
                             $rootScope.draftData = response.data;
                             var serverTimestamp = response.data.timestamp;

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -51,10 +51,7 @@ angular.module('bahmni.clinical')
                     }));
                 }
             };
-            var clearDraftObsFromTemplates = function () {
-                $rootScope.draftData = null;
-                $rootScope.resumeDraftOnLoad = false;
-                $rootScope.resumeDraftPatientUuid = null;
+            var clearStaleObsFromTemplates = function () {
                 $scope.consultation.selectedObsTemplate = [];
                 _.each($scope.consultation.observationForms, function (form) {
                     if (form.hasUnsavedFormObservations) {
@@ -64,13 +61,20 @@ angular.module('bahmni.clinical')
                 });
             };
 
+            var clearDraftObsFromTemplates = function () {
+                $rootScope.draftData = null;
+                $rootScope.resumeDraftOnLoad = false;
+                $rootScope.resumeDraftPatientUuid = null;
+                clearStaleObsFromTemplates();
+            };
+
             var loadDraftThenConcat = function () {
                 var patientUuid = $scope.patient ? $scope.patient.uuid : null;
                 var providerUuid = $rootScope.currentProvider ? $rootScope.currentProvider.uuid : null;
                 if ($scope.enableFormDraftFeature && !$rootScope.resumeDraftOnLoad && patientUuid && providerUuid && $scope.visitHistory && $scope.visitHistory.activeVisit) {
                     var promise = formDraftService.getDraft(patientUuid, providerUuid);
                     promise.then(function (response) {
-                        var visitClosed = $scope.visitHistory && !$scope.visitHistory.activeVisit;
+                        var visitClosed = !($scope.visitHistory && $scope.visitHistory.activeVisit);
                         if (!visitClosed && response && response.data && response.data.uuid && !response.data.markedAsSaved) {
                             $rootScope.draftData = response.data;
                         } else if (visitClosed) {
@@ -113,13 +117,7 @@ angular.module('bahmni.clinical')
                         return f.hasUnsavedFormObservations;
                     });
                     if (hasStaleUnsavedObs) {
-                        $scope.consultation.selectedObsTemplate = [];
-                        _.each($scope.consultation.observationForms, function (form) {
-                            if (form.hasUnsavedFormObservations) {
-                                form.observations = [];
-                                form.hasUnsavedFormObservations = false;
-                            }
-                        });
+                        clearStaleObsFromTemplates();
                     }
                 }
 

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -2648,5 +2648,107 @@ describe('ConceptSetPageController', function () {
             });
         });
     });
+
+    describe('Draft loading when visit is closed', function () {
+        var conceptResponseData;
+
+        beforeEach(function () {
+            var appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
+            appDescriptor.getConfigValue.and.returnValue(true);
+            appService.getAppDescriptor.and.returnValue(appDescriptor);
+
+            scope.patient = {uuid: 'test-patient-uuid'};
+            rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+
+            conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 'obs-uuid'}]}]};
+            mockConceptSetService(conceptResponseData);
+            mockformService({});
+        });
+
+        it('should clear stale rootScope draft state and draft obs from templates when visit is closed (else branch)', function () {
+            rootScope.draftData = {uuid: 'stale-draft', formData: 'stale-data', markedAsSaved: false};
+            rootScope.resumeDraftOnLoad = false;
+            scope.consultation.selectedObsTemplate = [{uuid: 'tmpl-1', hasUnsavedFormObservations: true, observations: [{value: 'draft-val'}]}];
+            scope.visitHistory = {activeVisit: null};
+
+            createController();
+
+            expect(rootScope.draftData).toBeNull();
+            expect(rootScope.resumeDraftOnLoad).toBe(false);
+            var hasAnyUnsaved = _.some(scope.consultation.selectedObsTemplate, function (t) { return t.hasUnsavedFormObservations; });
+            expect(hasAnyUnsaved).toBe(false);
+        });
+
+        it('should not pre-populate the form when visit is closed even if GET returns valid draft', function () {
+            formDraftService.getDraft.and.returnValue({
+                then: function (success) {
+                    success({data: {uuid: 'draft-uuid', formData: angular.toJson([{concept: {uuid: 'obs-uuid'}, value: 'draft-value'}]), markedAsSaved: false, timestamp: Date.now()}});
+                    return {catch: function () { return this; }};
+                }
+            });
+
+            scope.visitHistory = {activeVisit: null};
+
+            createController();
+
+            expect(rootScope.draftData).toBeNull();
+            expect(rootScope.resumeDraftOnLoad).toBeFalsy();
+        });
+
+        it('should reset resumeDraftOnLoad and clear draftData when GET returns null draft', function () {
+            formDraftService.getDraft.and.returnValue({
+                then: function (success) {
+                    success({data: {uuid: null, formData: null, markedAsSaved: null, timestamp: null}});
+                    return {catch: function () { return this; }};
+                }
+            });
+
+            rootScope.draftData = {uuid: 'stale-draft', formData: 'stale-data', markedAsSaved: false};
+            scope.visitHistory = {activeVisit: {uuid: 'active-visit-uuid'}};
+
+            createController();
+
+            expect(rootScope.draftData).toBeNull();
+            expect(rootScope.resumeDraftOnLoad).toBe(false);
+        });
+
+        it('should clear draft obs from templates when visit closes between GET condition check and response', function () {
+            formDraftService.getDraft.and.callFake(function () {
+                return {
+                    then: function (success) {
+                        scope.visitHistory = {activeVisit: null};
+                        success({data: {uuid: 'draft-uuid', formData: angular.toJson([{concept: {uuid: 'obs-uuid'}, value: 'draft-value'}]), markedAsSaved: false, timestamp: Date.now()}});
+                        return {catch: function () { return this; }};
+                    }
+                };
+            });
+
+            scope.consultation.selectedObsTemplate = [{uuid: 'tmpl-1', hasUnsavedFormObservations: true, observations: [{value: 'stale-draft-val'}]}];
+            scope.visitHistory = {activeVisit: {uuid: 'active-visit-uuid'}};
+
+            createController();
+
+            expect(rootScope.draftData).toBeNull();
+            expect(rootScope.resumeDraftOnLoad).toBeFalsy();
+            var hasAnyUnsaved = _.some(scope.consultation.selectedObsTemplate, function (t) { return t.hasUnsavedFormObservations; });
+            expect(hasAnyUnsaved).toBe(false);
+        });
+
+        it('should not set draftData from checkForExistingDrafts when visit is closed', function () {
+            formDraftService.getDraft.and.returnValue({
+                then: function (success) {
+                    success({data: {uuid: 'draft-uuid', formData: 'some-data', markedAsSaved: false, timestamp: Date.now()}});
+                    return {catch: function () { return this; }};
+                }
+            });
+
+            scope.visitHistory = {activeVisit: null};
+
+            createController();
+
+            expect(scope.formDraft.hasDrafts).toBeFalsy();
+            expect(rootScope.draftData).toBeNull();
+        });
+    });
 });
 

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -2749,6 +2749,28 @@ describe('ConceptSetPageController', function () {
             expect(scope.formDraft.hasDrafts).toBeFalsy();
             expect(rootScope.draftData).toBeNull();
         });
+
+        it('should clear stale hasUnsavedFormObservations in concatObservationForms when isDraftResumeValid is false and activeVisit is present', function () {
+            rootScope.resumeDraftOnLoad = false;
+            rootScope.draftData = null;
+            scope.visitHistory = {activeVisit: {uuid: 'active-visit-uuid'}};
+            // Pre-populate selectedObsTemplate so initializeDefaultTemplates is skipped,
+            // and set a stale unsaved form obs on observationForms to exercise the stale-obs guard
+            scope.consultation.selectedObsTemplate = [{uuid: 'tmpl-1', label: 'Template 1'}];
+            scope.consultation.observationForms = [{
+                formName: 'Form1',
+                hasUnsavedFormObservations: true,
+                observations: [{value: 'stale-form-val'}],
+                privileges: [],
+                isDefault: function () { return false; }
+            }];
+
+            createController();
+
+            var hasAnyFormUnsaved = _.some(scope.consultation.observationForms, function (f) { return f.hasUnsavedFormObservations; });
+            expect(hasAnyFormUnsaved).toBe(false);
+            expect(scope.consultation.observationForms[0].observations.length).toBe(0);
+        });
     });
 });
 


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=t7R8crQGbvWqPSwpH

Fix for Issue #4:
Stale 'Resume' banner allows pre-population of auto-deleted drafts across midnight boundary

Changes made:
When a visit is closed, clicking Resume will not give stale draft data anymore.