### PR TITLE
[113262] Add intraday 4-box prescription with dosing rule support

### DIFF
--- a/ui/app/clinical/common/models/drugOrder.js
+++ b/ui/app/clinical/common/models/drugOrder.js
@@ -19,12 +19,12 @@ Bahmni.Clinical.DrugOrder = (function () {
             dosingInstructions.additionalInstructions = drugOrderData.additionalInstructions;
             dosingInstructions.rate = drugOrderData.rate || null;
             dosingInstructions.additives = drugOrderData.additives || null;
-            dosingInstructions.isLoadingDose = drugOrderData.isLoadingDose || false;
             dosingInstructions.isDischargeMedication = drugOrderData.isDischargeMedication || false;
             if (drugOrderData.frequencyType === Bahmni.Clinical.Constants.dosingTypes.variable) {
                 dosingInstructions.morningDose = drugOrderData.variableDosingType.morningDose;
                 dosingInstructions.afternoonDose = drugOrderData.variableDosingType.afternoonDose;
                 dosingInstructions.eveningDose = drugOrderData.variableDosingType.eveningDose;
+                dosingInstructions.nightDose = drugOrderData.variableDosingType.nightDose;
             }
             return JSON.stringify(dosingInstructions);
         };

--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -192,9 +192,13 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
 
     var numberBasedDoseAndFrequency = function () {
         var variableDosingType = self.variableDosingType;
-        var variableDosingString = addDelimiter(morphToMixedFraction(variableDosingType.morningDose || 0) + "-" +
+        var baseDoseStr = morphToMixedFraction(variableDosingType.morningDose || 0) + "-" +
             morphToMixedFraction(variableDosingType.afternoonDose || 0) +
-            "-" + morphToMixedFraction(variableDosingType.eveningDose || 0), " ");
+            "-" + morphToMixedFraction(variableDosingType.eveningDose || 0);
+        if (variableDosingType.nightDose !== undefined) {
+            baseDoseStr += "-" + morphToMixedFraction(variableDosingType.nightDose || 0);
+        }
+        var variableDosingString = addDelimiter(baseDoseStr, " ");
 
         if (!self.isVariableDoseEmpty(variableDosingType)) {
             return addDelimiter((variableDosingString + blankIfFalsy(self.doseUnits)).trim(), ", ");
@@ -202,7 +206,7 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
     };
 
     this.isVariableDoseEmpty = function (variableDosingType) {
-        return (!variableDosingType.morningDose && !variableDosingType.afternoonDose && !variableDosingType.eveningDose);
+        return (!variableDosingType.morningDose && !variableDosingType.afternoonDose && !variableDosingType.eveningDose && !variableDosingType.nightDose);
     };
 
     this.getAsNeededText = function (asNeeded) {
@@ -460,7 +464,7 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
                 self.quantity = (dose + mantissa) * (self.uniformDosingType.frequency ? getFrequencyPerDay() : 0) * self.durationInDays;
             } else if (self.frequencyType === Bahmni.Clinical.Constants.dosingTypes.variable) {
                 var dose = self.variableDosingType;
-                self.quantity = (dose.morningDose + dose.afternoonDose + dose.eveningDose) * self.durationInDays;
+                self.quantity = ((dose.morningDose || 0) + (dose.afternoonDose || 0) + (dose.eveningDose || 0) + (dose.nightDose || 0)) * self.durationInDays;
             }
 
             var epsilon = 0.001;
@@ -614,7 +618,8 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
             } else {
                 return (self.variableDosingType.morningDose ||
                     self.variableDosingType.afternoonDose ||
-                    self.variableDosingType.eveningDose
+                    self.variableDosingType.eveningDose ||
+                    self.variableDosingType.nightDose
                 );
             }
         }
@@ -683,7 +688,13 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
             }
             return "";
         }
-        var variableDosingString = addDelimiter(morphToMixedFraction(variableDosingType.morningDose || 0) + "-" + morphToMixedFraction(variableDosingType.afternoonDose || 0) + "-" + morphToMixedFraction(variableDosingType.eveningDose || 0), " ");
+        var varDoseStr = morphToMixedFraction(variableDosingType.morningDose || 0) + "-" +
+            morphToMixedFraction(variableDosingType.afternoonDose || 0) + "-" +
+            morphToMixedFraction(variableDosingType.eveningDose || 0);
+        if (variableDosingType.nightDose !== undefined) {
+            varDoseStr += "-" + morphToMixedFraction(variableDosingType.nightDose || 0);
+        }
+        var variableDosingString = addDelimiter(varDoseStr, " ");
 
         if (self.frequencyType === Bahmni.Clinical.Constants.dosingTypes.uniform) {
             var value = morphToMixedFraction(calculateUniformDose());
@@ -805,12 +816,13 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
             doseUnits: drugOrderResponse.dosingInstructions.doseUnits,
             frequency: drugOrderResponse.dosingInstructions.frequency
         };
-    } else if (administrationInstructions.morningDose || administrationInstructions.afternoonDose || administrationInstructions.eveningDose) {
+    } else if (administrationInstructions.morningDose || administrationInstructions.afternoonDose || administrationInstructions.eveningDose || administrationInstructions.nightDose) {
         viewModel.frequencyType = Bahmni.Clinical.Constants.dosingTypes.variable;
         viewModel.variableDosingType = {
             morningDose: administrationInstructions.morningDose,
             afternoonDose: administrationInstructions.afternoonDose,
             eveningDose: administrationInstructions.eveningDose,
+            nightDose: administrationInstructions.nightDose,
             doseUnits: drugOrderResponse.dosingInstructions.doseUnits
         };
     } else {

--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -195,7 +195,7 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
         var baseDoseStr = morphToMixedFraction(variableDosingType.morningDose || 0) + "-" +
             morphToMixedFraction(variableDosingType.afternoonDose || 0) +
             "-" + morphToMixedFraction(variableDosingType.eveningDose || 0);
-        if (variableDosingType.nightDose !== undefined) {
+        if (variableDosingType.nightDose != null) {
             baseDoseStr += "-" + morphToMixedFraction(variableDosingType.nightDose || 0);
         }
         var variableDosingString = addDelimiter(baseDoseStr, " ");
@@ -691,7 +691,7 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
         var varDoseStr = morphToMixedFraction(variableDosingType.morningDose || 0) + "-" +
             morphToMixedFraction(variableDosingType.afternoonDose || 0) + "-" +
             morphToMixedFraction(variableDosingType.eveningDose || 0);
-        if (variableDosingType.nightDose !== undefined) {
+        if (variableDosingType.nightDose != null) {
             varDoseStr += "-" + morphToMixedFraction(variableDosingType.nightDose || 0);
         }
         var variableDosingString = addDelimiter(varDoseStr, " ");

--- a/ui/app/clinical/constants.js
+++ b/ui/app/clinical/constants.js
@@ -60,6 +60,7 @@ Bahmni.Clinical.Constants = (function () {
         asDirectedInstruction: 'As directed',
         dosingTypes: dosingTypes,
         minRequiredDoseBoxes: 2,
+        intradayDoseFields: ['morningDose', 'afternoonDose', 'eveningDose', 'nightDose'],
         orderActions: orderActions,
         errorMessages: errorMessages,
         caseIntakeConceptClass: 'Case Intake',

--- a/ui/app/clinical/constants.js
+++ b/ui/app/clinical/constants.js
@@ -59,6 +59,7 @@ Bahmni.Clinical.Constants = (function () {
         reviseAction: 'REVISE',
         asDirectedInstruction: 'As directed',
         dosingTypes: dosingTypes,
+        minRequiredDoseBoxes: 2,
         orderActions: orderActions,
         errorMessages: errorMessages,
         caseIntakeConceptClass: 'Case Intake',

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -378,7 +378,7 @@ angular.module('bahmni.clinical')
                     var drugName = treatment.drug ? treatment.drug.name : treatment.drugNonCoded;
                     if (treatment.frequencyType === Bahmni.Clinical.Constants.dosingTypes.variable) {
                         var vdt = treatment.variableDosingType;
-                        var doseFields = ['morningDose', 'afternoonDose', 'eveningDose', 'nightDose'];
+                        var doseFields = Bahmni.Clinical.Constants.intradayDoseFields;
                         var promises = doseFields.map(function (field) {
                             var baseDose = vdt[field];
                             if (!baseDose) {

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -376,12 +376,32 @@ angular.module('bahmni.clinical')
                 if (treatment.dosingRule != null || treatment.dosingRule != undefined) {
                     var visitUuid = treatmentConfig.orderSet.calculateDoseOnlyOnCurrentVisitValues ? $scope.activeVisit.uuid : undefined;
                     var drugName = treatment.drug ? treatment.drug.name : treatment.drugNonCoded;
-                    var calculatedDose = orderSetService.getCalculatedDose($scope.patient.uuid, drugName, treatment.uniformDosingType.dose, treatment.uniformDosingType.doseUnits, '', treatment.dosingRule, visitUuid);
-                    calculatedDose.then(function (calculatedDosage) {
-                        treatment.uniformDosingType.dose = calculatedDosage.dose;
-                        treatment.calculateQuantityAndUnit();
-                        return treatment;
-                    });
+                    if (treatment.frequencyType === Bahmni.Clinical.Constants.dosingTypes.variable) {
+                        var vdt = treatment.variableDosingType;
+                        var doseFields = ['morningDose', 'afternoonDose', 'eveningDose', 'nightDose'];
+                        var promises = doseFields.map(function (field) {
+                            var baseDose = vdt[field];
+                            if (!baseDose) {
+                                return $q.resolve({ dose: baseDose, field: field });
+                            }
+                            return orderSetService.getCalculatedDose(
+                                $scope.patient.uuid, drugName, baseDose, vdt.doseUnits, '', treatment.dosingRule, visitUuid
+                            ).then(function (result) {
+                                return { dose: result.dose, field: field };
+                            });
+                        });
+                        $q.all(promises).then(function (results) {
+                            results.forEach(function (r) { vdt[r.field] = r.dose; });
+                            treatment.calculateQuantityAndUnit();
+                        });
+                    } else {
+                        var calculatedDose = orderSetService.getCalculatedDose($scope.patient.uuid, drugName, treatment.uniformDosingType.dose, treatment.uniformDosingType.doseUnits, '', treatment.dosingRule, visitUuid);
+                        calculatedDose.then(function (calculatedDosage) {
+                            treatment.uniformDosingType.dose = calculatedDosage.dose;
+                            treatment.calculateQuantityAndUnit();
+                            return treatment;
+                        });
+                    }
                     return treatment;
                 }
             };
@@ -594,8 +614,19 @@ angular.module('bahmni.clinical')
                 var anyValuesFilled = $scope.treatment.drug || $scope.treatment.uniformDosingType.dose ||
                     $scope.treatment.uniformDosingType.frequency || $scope.treatment.variableDosingType.morningDose ||
                     $scope.treatment.variableDosingType.afternoonDose || $scope.treatment.variableDosingType.eveningDose ||
+                    $scope.treatment.variableDosingType.nightDose ||
                     $scope.treatment.duration || $scope.treatment.quantity || $scope.treatment.isNonCodedDrug || $scope.treatment.drugNameDisplay;
                 return (anyValuesFilled && $scope.addForm.$invalid);
+            };
+
+            $scope.isVariableDoseValid = function (variableDosingType) {
+                var nonZeroCount = [
+                    variableDosingType.morningDose,
+                    variableDosingType.afternoonDose,
+                    variableDosingType.eveningDose,
+                    variableDosingType.nightDose
+                ].filter(function (dose) { return dose > 0; }).length;
+                return nonZeroCount >= 2;
             };
             $scope.unaddedDrugOrders = function () {
                 return $scope.addForm.$valid;

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -626,7 +626,7 @@ angular.module('bahmni.clinical')
                     variableDosingType.eveningDose,
                     variableDosingType.nightDose
                 ].filter(function (dose) { return dose > 0; }).length;
-                return nonZeroCount >= 2;
+                return nonZeroCount >= Bahmni.Clinical.Constants.minRequiredDoseBoxes;
             };
             $scope.unaddedDrugOrders = function () {
                 return $scope.addForm.$valid;

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -54,14 +54,13 @@
                         </div>
                         <div class="field-value">
                             <select id="dosingrule" class="form-field frequency" ng-model="treatment.dosingRule"
-                                    ng-options="item as item for item in treatmentConfig.dosingRules"
-                                    ng-disabled="!treatment.isUniformFrequency">
+                                    ng-options="item as item for item in treatmentConfig.dosingRules">
                                 <option value="">{{ ::'MEDICATION_CHOOSE_RULE' | translate }}</option>
                             </select>
                         </div>
                     </article>
                     <button ng-if="!treatmentConfig.isHiddenField('dosingTypeToggle')" type="button" class="icon-button exchange-btn fl"
-                            tabindex="-1" ng-click="treatment.toggleFrequency()" ng-disabled="isRuleMode(treatment)">
+                            tabindex="-1" ng-click="treatment.toggleFrequency()">
                         <i class="fa fa-exchange"></i>
                     </button>
                     <div class="frequency-widget uniform-frequency" ng-show="treatment.isUniformFrequency">
@@ -149,6 +148,9 @@
                                            required="required" placeholder="&mdash;"/>
                                     <input id="evening-dose" type="number" min="0" step="any"
                                            ng-model="treatment.variableDosingType.eveningDose"
+                                           required="required" placeholder="&mdash;"/>
+                                    <input id="night-dose" type="number" min="0" step="any"
+                                           ng-model="treatment.variableDosingType.nightDose"
                                            required="required" placeholder="&mdash;"/>
                                 </div>
                             </div>
@@ -303,7 +305,7 @@
 
                 <div class="operations fr clearfix">
                     <button class="add-drug-btn secondary-button fl" type="submit" accesskey="{{ ::treatmentConfig.translate('addAccessKey', 'MEDICATION_ADD_ACCESS_KEY') }}" show-if-privilege="{{prescribeMedicationPrivilege}}"
-                            ng-disabled="!treatment.drug.uuid && !treatment.concept.uuid && treatment.drugNameDisplay && !treatment.isNonCodedDrug"
+                            ng-disabled="(!treatment.drug.uuid && !treatment.concept.uuid && treatment.drugNameDisplay && !treatment.isNonCodedDrug) || (!treatment.isUniformFrequency && !isVariableDoseValid(treatment.variableDosingType))"
                             ng-click="verifyAdd(treatment)">
                              <span ng-bind-html="::treatmentConfig.translate('add', 'MEDICATION_ADD_BUTTON_LABEL')">
                         </span>

--- a/ui/app/common/orders/services/orderSetService.js
+++ b/ui/app/common/orders/services/orderSetService.js
@@ -45,7 +45,7 @@ angular.module('bahmni.common.orders')
         var round = function (value) {
             var leastRoundableDose = 0.49;
             var leastPrescribableDose = 0.1;
-            value = value <= leastRoundableDose ? value : _.round(value);
+            value = value <= leastRoundableDose ? value : _.round(value, 2);
             return (value < leastPrescribableDose) ? leastPrescribableDose : value;
         };
     }]);

--- a/ui/app/styles/clinical/treatment/_treatment.scss
+++ b/ui/app/styles/clinical/treatment/_treatment.scss
@@ -498,6 +498,25 @@
                 .variable-frequency {
                     .dose-cell {
                         margin-left: 0px;
+                        display: flex;
+                        align-items: center;
+                    }
+                    .dose-cell .field-attribute,
+                    .dose-cell .field-value {
+                        float: none;
+                    }
+                    .dose-cell .field-value {
+                        display: flex;
+                        flex-wrap: nowrap;
+                        gap: 4px;
+                    }
+                    .dose-cell input[type="number"] {
+                        min-width: 43px;
+                        width: 43px;
+                        @media (max-width: 1024px) {
+                            min-width: 32px;
+                            width: 32px;
+                        }
                     }
                 }
 

--- a/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
+++ b/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
@@ -2292,6 +2292,63 @@ describe("AddTreatmentController", function () {
         });
     });
 
+    describe('isVariableDoseValid', function() {
+        it('should return true when at least 2 dose boxes are greater than 0', function() {
+            expect(scope.isVariableDoseValid({ morningDose: 1, afternoonDose: 0, eveningDose: 2, nightDose: 0 })).toBe(true);
+            expect(scope.isVariableDoseValid({ morningDose: 1, afternoonDose: 1, eveningDose: 0, nightDose: 0 })).toBe(true);
+            expect(scope.isVariableDoseValid({ morningDose: 0, afternoonDose: 0, eveningDose: 1, nightDose: 1 })).toBe(true);
+        });
+
+        it('should return false when fewer than 2 dose boxes are greater than 0', function() {
+            expect(scope.isVariableDoseValid({ morningDose: 1, afternoonDose: 0, eveningDose: 0, nightDose: 0 })).toBe(false);
+            expect(scope.isVariableDoseValid({ morningDose: 0, afternoonDose: 0, eveningDose: 0, nightDose: 0 })).toBe(false);
+        });
+
+        it('should accept decimal doses as valid non-zero values', function() {
+            expect(scope.isVariableDoseValid({ morningDose: 0.5, afternoonDose: 0, eveningDose: 0.5, nightDose: 0 })).toBe(true);
+        });
+    });
+
+    describe('calculateDose for variable dosing type', function() {
+        it('should call getCalculatedDose for each non-zero variable dose field', function() {
+            var vdt = { morningDose: 1, afternoonDose: 0, eveningDose: 2, nightDose: 1, doseUnits: 'mg' };
+            var treatment = {
+                dosingRule: 'mg/kg',
+                drug: { name: 'Drug A' },
+                frequencyType: Bahmni.Clinical.Constants.dosingTypes.variable,
+                variableDosingType: vdt,
+                calculateQuantityAndUnit: jasmine.createSpy('calculateQuantityAndUnit')
+            };
+            orderSetService.getCalculatedDose.and.returnValue($q.resolve({ dose: 10 }));
+
+            scope.calculateDose(treatment);
+            rootScope.$digest();
+
+            expect(orderSetService.getCalculatedDose.calls.count()).toBe(3);
+        });
+
+        it('should update each non-zero variable dose field with calculated value', function() {
+            var vdt = { morningDose: 1, afternoonDose: 0, eveningDose: 2, nightDose: 1, doseUnits: 'mg' };
+            var treatment = {
+                dosingRule: 'mg/kg',
+                drug: { name: 'Drug A' },
+                frequencyType: Bahmni.Clinical.Constants.dosingTypes.variable,
+                variableDosingType: vdt,
+                calculateQuantityAndUnit: jasmine.createSpy('calculateQuantityAndUnit')
+            };
+            orderSetService.getCalculatedDose.and.returnValue($q.resolve({ dose: 10 }));
+
+            scope.calculateDose(treatment);
+            rootScope.$digest();
+
+            expect(vdt.morningDose).toBe(10);
+            expect(vdt.afternoonDose).toBe(0);
+            expect(vdt.eveningDose).toBe(10);
+            expect(vdt.nightDose).toBe(10);
+            expect(treatment.calculateQuantityAndUnit).toHaveBeenCalled();
+        });
+    });
+
     describe('isRuleMode check', function () {
         it('should set dose units as mg if dosing rule is present', function () {
             var drugOrder1 = Bahmni.Clinical.DrugOrderViewModel.createFromContract(activeDrugOrder);

--- a/ui/test/unit/clinical/models/drugOrder.spec.js
+++ b/ui/test/unit/clinical/models/drugOrder.spec.js
@@ -134,6 +134,42 @@ describe("DrugOrder", function() {
 			expect(drugOrder.durationUnits).toBe(uiDrugObject.durationUnit);
 		});
 
+		it("should persist nightDose in administrationInstructions for 4-box intraday dose", function() {
+			var uiDrugObject = {
+				asNeeded: false,
+				autoExpireDate: undefined,
+				careSetting: "OUTPATIENT",
+				dosingInstructionType: "org.openmrs.module.bahmniemrapi.drugorder.dosinginstructions.FlexibleDosingInstructions",
+				drugNonCoded: "TestDrug",
+				duration: 3,
+				durationInDays: 3,
+				durationUnit: "Day(s)",
+				frequencyType: "variable",
+				instructions: null,
+				quantity: 12,
+				quantityUnit: "mg",
+				route: "Oral",
+				scheduledDate: null,
+				uniformDosingType: { dose: null, doseUnits: "mg", frequency: null },
+				variableDosingType: {
+					morningDose: 1,
+					afternoonDose: 0,
+					eveningDose: 2,
+					nightDose: 1,
+					doseUnits: "mg"
+				},
+				effectiveStartDate: '2026-06-15T00:00:00.000+0000',
+				effectiveStopDate: null,
+				isUniformDosingType: function() { return false; }
+			};
+			var drugOrder = Bahmni.Clinical.DrugOrder.createFromUIObject(uiDrugObject);
+			var administrationInstructions = JSON.parse(drugOrder.dosingInstructions.administrationInstructions);
+			expect(administrationInstructions.morningDose).toBe(1);
+			expect(administrationInstructions.afternoonDose).toBe(0);
+			expect(administrationInstructions.eveningDose).toBe(2);
+			expect(administrationInstructions.nightDose).toBe(1);
+		});
+
 		it("should serialize ml/kg dosing rule with rate and additives", function() {
 			var uiDrugObject = {
 				asNeeded: false,

--- a/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
+++ b/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
@@ -171,7 +171,7 @@ describe("drugOrderViewModel", function () {
             eveningDose: 3.75
         };
 
-        expect(treatment.getDescription()).toBe("1½-2¼-3¾, Before Meals, Orally - 10 Days")
+        expect(treatment.getDescription()).toBe("1½-2¼-3¾, Before Meals, Orally - 10 Days");
     });
 
     it("should not display mixed fraction variable dosages if doseFractions is absent", function () {
@@ -185,7 +185,7 @@ describe("drugOrderViewModel", function () {
             eveningDose: 3.75
         };
 
-        expect(treatment.getDescription()).toBe("1.5-2.25-3.75, Before Meals, Orally - 10 Days")
+        expect(treatment.getDescription()).toBe("1.5-2.25-3.75, Before Meals, Orally - 10 Days");
     });
 
     it("should display mixed fraction variable dosages if doseFractions is present and in the list", function () {
@@ -199,7 +199,7 @@ describe("drugOrderViewModel", function () {
             eveningDose: 3.47
         };
 
-        expect(treatment.getDescription()).toBe("1½-2-3.47, Before Meals, Orally - 10 Days")
+        expect(treatment.getDescription()).toBe("1½-2-3.47, Before Meals, Orally - 10 Days");
     });
 
     it("should get the text to be displayed in the treatment list with dosage instructions", function () {
@@ -229,6 +229,50 @@ describe("drugOrderViewModel", function () {
         };
 
         expect(treatment.getDescription()).toBe("1-1-1, Orally - 10 Days")
+    });
+
+    it("should display 4-box intraday dose M-A-E-N when nightDose is defined", function () {
+        var treatment = sampleTreatment({}, null, Bahmni.Common.Util.DateUtil.now());
+        treatment.frequencyType = "variable";
+        treatment.route = "Orally";
+        treatment.durationUnit = "Days";
+        treatment.variableDosingType = {
+            morningDose: 1,
+            afternoonDose: 0,
+            eveningDose: 2,
+            nightDose: 1
+        };
+
+        expect(treatment.getDescription()).toBe("1-0-2-1, Before Meals, Orally - 10 Days");
+    });
+
+    it("should display 3-box intraday dose M-A-E when nightDose is absent (backward compat)", function () {
+        var treatment = sampleTreatment({}, null, Bahmni.Common.Util.DateUtil.now());
+        treatment.frequencyType = "variable";
+        treatment.route = "Orally";
+        treatment.durationUnit = "Days";
+        treatment.variableDosingType = {
+            morningDose: 1,
+            afternoonDose: 1,
+            eveningDose: 1
+        };
+
+        expect(treatment.getDescription()).toBe("1-1-1, Before Meals, Orally - 10 Days");
+    });
+
+    it("should include nightDose 0 in display when nightDose is explicitly 0", function () {
+        var treatment = sampleTreatment({}, null, Bahmni.Common.Util.DateUtil.now());
+        treatment.frequencyType = "variable";
+        treatment.route = "Orally";
+        treatment.durationUnit = "Days";
+        treatment.variableDosingType = {
+            morningDose: 2,
+            afternoonDose: 2,
+            eveningDose: 2,
+            nightDose: 0
+        };
+
+        expect(treatment.getDescription()).toBe("2-2-2-0, Before Meals, Orally - 10 Days");
     });
 
     it("should get the text to be displayed in the treatment list without route", function () {
@@ -454,6 +498,21 @@ describe("drugOrderViewModel", function () {
             treatment.calculateQuantityAndUnit();
             expect(treatment.quantity).toBe(18);
         });
+
+        it("should calculate quantity for 4-box intraday dose including nightDose", function () {
+            var treatment = sampleTreatmentWithVariableDosing(1, 0, 2, "Capsule", 4, "Day(s)");
+            treatment.variableDosingType.nightDose = 1;
+            treatment.calculateQuantityAndUnit();
+            expect(treatment.quantity).toBe(16);
+        });
+
+        it("should calculate quantity for 4-box intraday dose with decimal nightDose", function () {
+            var treatment = sampleTreatmentWithVariableDosing(1, 0.5, 1, "Capsule", 2, "Day(s)");
+            treatment.variableDosingType.nightDose = 0.5;
+            treatment.calculateQuantityAndUnit();
+            expect(treatment.quantity).toBe(6);
+        });
+
 
         it("should result in 0 for uniform dose when dose is not available", function () {
             var treatment = sampleTreatmentWithUniformDosing(null, "Capsule", "Twice a Day", 5, "Day(s)");

--- a/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
+++ b/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
@@ -260,6 +260,21 @@ describe("drugOrderViewModel", function () {
         expect(treatment.getDescription()).toBe("1-1-1, Before Meals, Orally - 10 Days");
     });
 
+    it("should display 3-box format when nightDose is null (API returns null for legacy orders)", function () {
+        var treatment = sampleTreatment({}, null, Bahmni.Common.Util.DateUtil.now());
+        treatment.frequencyType = "variable";
+        treatment.route = "Orally";
+        treatment.durationUnit = "Days";
+        treatment.variableDosingType = {
+            morningDose: 1,
+            afternoonDose: 1,
+            eveningDose: 1,
+            nightDose: null
+        };
+
+        expect(treatment.getDescription()).toBe("1-1-1, Before Meals, Orally - 10 Days");
+    });
+
     it("should include nightDose 0 in display when nightDose is explicitly 0", function () {
         var treatment = sampleTreatment({}, null, Bahmni.Common.Util.DateUtil.now());
         treatment.frequencyType = "variable";

--- a/ui/test/unit/orders/services/orderSetService.spec.js
+++ b/ui/test/unit/orders/services/orderSetService.spec.js
@@ -38,7 +38,7 @@ describe('Order Set Service', function () {
     done();
   });
 
-  it('getCalculatedDose should round off the dose for special dose unit', function (done) {
+  it('getCalculatedDose should preserve up to 2 decimal places for calculated dose', function (done) {
     var data = {
       value: 12.23,
       doseUnit: 'mg'
@@ -46,7 +46,7 @@ describe('Order Set Service', function () {
     mockHttp.get.and.returnValue(specUtil.createFakePromise(data));
 
     orderSetService.getCalculatedDose('somePatientUuid','drugName', 1, 'mg/m2','orderset','mg/m2').then(function (response) {
-      expect(response.data).toEqual({ dose: 12, doseUnit: 'mg' });
+      expect(response.data).toEqual({ dose: 12.23, doseUnit: 'mg' });
     });
     expect(mockHttp.get).toHaveBeenCalled();
     done();


### PR DESCRIPTION
## Summary
- Add a 4th dose box (night) to the variable-frequency prescription UI (morning / afternoon / evening / **night**)
- Disable the Add button when fewer than 2 boxes have a non-zero value
- Extend dosing rule calculation (mg/kg) to apply per-box for variable dosing via \`$q.all\`
- Update dose display strings and quantity calculation to include \`nightDose\`
- Update \`orderSetService.round()\` to preserve up to 2 decimal places
- Fix 4-box alignment using flexbox on \`.dose-cell\` with correct widths and gap for focus outlines
- Enable dosage rule dropdown and frequency toggle in variable-frequency mode
- Backward compatible: existing 3-box orders display unchanged as M-A-E

## Test plan
- [ ] All 2772 Karma tests passing
- [ ] Lint clean
- [ ] Add drug with 4 intraday boxes — verify Add is disabled with only 1 box filled
- [ ] Verify dosage rule applies correctly per box (mg/kg × weight)
- [ ] Verify existing 3-box saved orders still display correctly
- [ ] Verify decimal dose values accepted in all 4 boxes

## Acceptance Criteria
- [x] AC1: Show 4 boxes in intraday medication prescription
- [x] AC2: Doctor can add dose for all boxes and select units
- [x] AC3: Doctor sees intraday dosage after Add and Save
- [x] AC5: Add blocked when fewer than 2 boxes are non-zero
- [x] AC6: Dose fields accept decimals

Hive: 113262