### PR TITLE
Pooja | Hive-117252 | Editing of a form should be disabled if draft is present

### DIFF
--- a/micro-frontends/src/next-ui/Containers/formDisplayControl/FormDisplayControl.jsx
+++ b/micro-frontends/src/next-ui/Containers/formDisplayControl/FormDisplayControl.jsx
@@ -351,16 +351,22 @@ export function FormDisplayControl(props) {
                                   {comments.has(entry.encounterUuid) && <Chat />}
                                   {checkForPrivileges(entry, "edit") &&
                                     showEdit(entry.encounterUuid) && (
-                                      <i
-                                        className="fa fa-pencil"
-                                        onClick={() => {
-                                          openEditObservationForm(
-                                            key,
-                                            entry.encounterUuid,
-                                            entry.formNameTranslations
-                                          );
-                                        }}
-                                      ></i>
+                                      props?.hostData?.draftFormNames?.includes(key) ? (
+                                        <i
+                                          className="fa fa-pencil pencil-disabled"
+                                        ></i>
+                                      ) : (
+                                        <i
+                                          className="fa fa-pencil"
+                                          onClick={() => {
+                                            openEditObservationForm(
+                                              key,
+                                              entry.encounterUuid,
+                                              entry.formNameTranslations
+                                            );
+                                          }}
+                                        ></i>
+                                      )
                                     )}
                                 </div>
                                 <span className={"form-provider-text"}>

--- a/micro-frontends/src/next-ui/Containers/formDisplayControl/FormDisplayControl.spec.jsx
+++ b/micro-frontends/src/next-ui/Containers/formDisplayControl/FormDisplayControl.spec.jsx
@@ -316,4 +316,60 @@ describe("FormDisplayControl Component with Accordion", () => {
       expect(container.querySelectorAll(".fa.fa-pencil")).toHaveLength(0);
     });
   });
+
+  it("should show disabled pencil icon when a draft exists for that form", async () => {
+    const hostDataWithDraft = {
+      patientUuid: "some-patient-uuid",
+      showEditForActiveEncounter: false,
+      encounterUuid: "6e52cecd-a095-457f-9515-38cf9178cb50",
+      draftFormNames: ["Orthopaedic Triage"],
+    };
+    const { container } = render(
+      <FormDisplayControl hostData={hostDataWithDraft} appService={mockAppService} />
+    );
+
+    await waitFor(() => {
+      const disabledPencils = container.querySelectorAll(".fa.fa-pencil.pencil-disabled");
+      const clickablePencils = container.querySelectorAll(".fa.fa-pencil:not(.pencil-disabled)");
+      expect(disabledPencils).toHaveLength(1);
+      expect(clickablePencils).toHaveLength(3);
+    });
+  });
+
+  it("should show all pencil icons as clickable when no draft exists", async () => {
+    const hostDataNoDraft = {
+      patientUuid: "some-patient-uuid",
+      showEditForActiveEncounter: false,
+      encounterUuid: "6e52cecd-a095-457f-9515-38cf9178cb50",
+      draftFormNames: [],
+    };
+    const { container } = render(
+      <FormDisplayControl hostData={hostDataNoDraft} appService={mockAppService} />
+    );
+
+    await waitFor(() => {
+      const disabledPencils = container.querySelectorAll(".fa.fa-pencil.pencil-disabled");
+      const clickablePencils = container.querySelectorAll(".fa.fa-pencil:not(.pencil-disabled)");
+      expect(disabledPencils).toHaveLength(0);
+      expect(clickablePencils).toHaveLength(4);
+    });
+  });
+
+  it("should not disable pencil when draftFormNames contains a different form name", async () => {
+    const hostDataOtherDraft = {
+      patientUuid: "some-patient-uuid",
+      showEditForActiveEncounter: false,
+      encounterUuid: "6e52cecd-a095-457f-9515-38cf9178cb50",
+      draftFormNames: ["Some Other Form"],
+    };
+    const { container } = render(
+      <FormDisplayControl hostData={hostDataOtherDraft} appService={mockAppService} />
+    );
+
+    await waitFor(() => {
+      const disabledPencils = container.querySelectorAll(".fa.fa-pencil.pencil-disabled");
+      expect(disabledPencils).toHaveLength(0);
+      expect(container.querySelectorAll(".fa.fa-pencil")).toHaveLength(4);
+    });
+  });
 });

--- a/micro-frontends/src/next-ui/Containers/formDisplayControl/formDisplayControl.scss
+++ b/micro-frontends/src/next-ui/Containers/formDisplayControl/formDisplayControl.scss
@@ -103,6 +103,11 @@
   color: #669999;
 }
 
+.pencil-disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 
 .form-accordion-title {
   display: flex;

--- a/micro-frontends/src/next-ui/Containers/formDisplayControl/formDisplayControl.scss
+++ b/micro-frontends/src/next-ui/Containers/formDisplayControl/formDisplayControl.scss
@@ -106,6 +106,7 @@
 .pencil-disabled {
   opacity: 0.4;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 

--- a/micro-frontends/src/utils/bridge-builder.js
+++ b/micro-frontends/src/utils/bridge-builder.js
@@ -117,6 +117,12 @@ function translationForwardingController($scope, $translate, appService) {
   $scope.hostApi = vm.hostApi;
   $scope.tx = $translate.instant.bind($translate);
   $scope.appService = appService;
+
+  // $onChanges is not called for '=' bindings in AngularJS, so watch
+  // vm.hostData explicitly to propagate reference changes to the template.
+  $scope.$watch(function () { return vm.hostData; }, function (newVal) {
+    $scope.hostData = newVal;
+  });
 }
 
 translationForwardingController.$inject = ["$scope", "$translate","appService"];

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -148,8 +148,12 @@ angular.module('bahmni.clinical')
                         var matchingTemplate = _.find($scope.allTemplates, function (t) {
                             return t.uuid === draftObs.concept.uuid;
                         });
-                        if (matchingTemplate && (!matchingTemplate.observations || matchingTemplate.observations.length === 0)) {
-                            matchingTemplate.observations = [stripObservationFlags(draftObs)];
+                        if (matchingTemplate) {
+                            if (!matchingTemplate.observations || matchingTemplate.observations.length === 0) {
+                                matchingTemplate.observations = [stripObservationFlags(draftObs)];
+                            } else {
+                                formDirtyStateService.populateObservationValues(matchingTemplate.observations[0], stripObservationFlags(draftObs));
+                            }
                             matchingTemplate.hasUnsavedFormObservations = true;
                         }
                     });
@@ -594,6 +598,7 @@ angular.module('bahmni.clinical')
                     var draftDate = $filter('date')(savedDate, 'dd MMM yyyy');
                     var draftTime = $filter('date')(savedDate, 'hh:mm a');
 
+                    $rootScope.draftData = response.data;
                     $scope.formDraft.statusMessage = 'SAVED_AS_DRAFT_KEY';
                     $scope.formDraft.statusParams = {draftDate: draftDate, draftTime: draftTime};
                     $scope.formDraft.draftDate = draftDate;

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -753,6 +753,7 @@ angular.module('bahmni.clinical')
                 $scope.formDraft.hasDrafts = false;
                 dirtyTrackingState.postSaveRefreshPending = true;
                 $scope.formDraft.showSpinner = false;
+                $rootScope.draftData = null;
                 clearDraftStatus(true);
                 if (dirtyTrackingState.postSaveRefreshTimeout) {
                     $timeout.cancel(dirtyTrackingState.postSaveRefreshTimeout);

--- a/ui/app/common/displaycontrols/dashboard/directives/dashboard.js
+++ b/ui/app/common/displaycontrols/dashboard/directives/dashboard.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.dashboard')
-    .directive('dashboard', ['appService', '$stateParams', '$bahmniCookieStore', 'configurations', 'encounterService', 'spinner', 'auditLogService', 'messagingService', '$state', '$translate', 'formPrintService', function (appService, $stateParams, $bahmniCookieStore, configurations, encounterService, spinner, auditLogService, messagingService, $state, $translate, formPrintService) {
+    .directive('dashboard', ['appService', '$stateParams', '$bahmniCookieStore', 'configurations', 'encounterService', 'spinner', 'auditLogService', 'messagingService', '$state', '$translate', 'formPrintService', 'formDraftService', function (appService, $stateParams, $bahmniCookieStore, configurations, encounterService, spinner, auditLogService, messagingService, $state, $translate, formPrintService, formDraftService) {
         var controller = function ($scope, $filter, $rootScope) {
             var dashboardConfig = null;
 
@@ -37,7 +37,8 @@ angular.module('bahmni.common.displaycontrol.dashboard')
                     configurations.consultationNoteConcept(), configurations.labOrderNotesConcept()),
                     editErrorMessage: $translate.instant('CLINICAL_FORM_ERRORS_MESSAGE_KEY'),
                     showPrintOption: (dashboardConfig && dashboardConfig.printing) ? true : false,
-                    currentProvider: $rootScope.currentProvider
+                    currentProvider: $rootScope.currentProvider,
+                    draftFormNames: formDraftService.getFormNamesFromDraft($rootScope.draftData)
                 };
                 $scope.formApi = {
                     handleEditSave: function (encounter) {
@@ -84,6 +85,19 @@ angular.module('bahmni.common.displaycontrol.dashboard')
             }
 
             var sectionFormDataCache = new WeakMap();
+
+            var cleanUpDraftWatch = $rootScope.$watch('draftData', function (newVal, oldVal) {
+                if (newVal === oldVal) { return; }
+                if ($scope.formData) {
+                    $scope.formData.draftFormNames = formDraftService.getFormNamesFromDraft(newVal);
+                    sectionFormDataCache = new WeakMap();
+                }
+            });
+
+            $scope.$on('$destroy', function () {
+                cleanUpDraftWatch();
+            });
+
             $scope.getSectionFormData = function (section) {
                 if (!section) return $scope.formData;
                 if (!sectionFormDataCache.has(section)) {

--- a/ui/app/common/displaycontrols/forms/directives/formsTable.js
+++ b/ui/app/common/displaycontrols/forms/directives/formsTable.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.forms')
-    .directive('formsTable', ['conceptSetService', 'spinner', '$q', 'visitFormService', 'appService', '$state', '$rootScope',
-        function (conceptSetService, spinner, $q, visitFormService, appService, $state, $rootScope) {
+    .directive('formsTable', ['conceptSetService', 'spinner', '$q', 'visitFormService', 'appService', '$state', '$rootScope', 'formDraftService',
+        function (conceptSetService, spinner, $q, visitFormService, appService, $state, $rootScope, formDraftService) {
             var defaultController = function ($scope) {
                 $scope.shouldPromptBrowserReload = true;
                 $scope.showFormsDate = appService.getAppDescriptor().getConfigValue("showFormsDate");
@@ -66,6 +66,22 @@ angular.module('bahmni.common.displaycontrol.forms')
                         }
                     } else { return true; }
                 };
+
+                $scope.draftFormConceptUuids = [];
+
+                var updateDraftFormConceptUuids = function (draftData) {
+                    $scope.draftFormConceptUuids = _.compact(_.map(
+                        _.filter(formDraftService.parseDraftObs(draftData), function (obs) {
+                            return obs.concept && !obs.formFieldPath;
+                        }),
+                        function (obs) { return obs.concept.uuid; }
+                    ));
+                };
+
+                $scope.hasFormDraft = function (data) {
+                    return $scope.draftFormConceptUuids.indexOf(data.concept.uuid) !== -1;
+                };
+
                 var init = function () {
                     $scope.formsNotFound = false;
                     return $q.all([getAllObservationTemplates(), obsFormData()]).then(function (results) {
@@ -83,6 +99,17 @@ angular.module('bahmni.common.displaycontrol.forms')
                         }
                     });
                 };
+
+                updateDraftFormConceptUuids($rootScope.draftData);
+
+                var cleanUpDraftWatch = $rootScope.$watch('draftData', function (newVal, oldVal) {
+                    if (newVal === oldVal) { return; }
+                    updateDraftFormConceptUuids(newVal);
+                });
+
+                $scope.$on("$destroy", function () {
+                    cleanUpDraftWatch();
+                });
 
                 $scope.getDisplayName = function (data) {
                     var concept = data.concept;

--- a/ui/app/common/displaycontrols/forms/directives/formsTable.js
+++ b/ui/app/common/displaycontrols/forms/directives/formsTable.js
@@ -79,6 +79,7 @@ angular.module('bahmni.common.displaycontrol.forms')
                 };
 
                 $scope.hasFormDraft = function (data) {
+                    if (!data || !data.concept) { return false; }
                     return $scope.draftFormConceptUuids.indexOf(data.concept.uuid) !== -1;
                 };
 

--- a/ui/app/common/displaycontrols/forms/views/formsTable.html
+++ b/ui/app/common/displaycontrols/forms/views/formsTable.html
@@ -30,13 +30,17 @@
                                   ng-dialog-scope="this">
                                 <i class="fa fa-eye"></i>
                             </span>
-                            <span ng-show="doesUserHaveAccessToTheForm(data, 'edit') && showEditForActiveEncounter(data.encounterUuid)" class="has-link fl formDataEdit"
+                            <span ng-show="doesUserHaveAccessToTheForm(data, 'edit') && showEditForActiveEncounter(data.encounterUuid) && !hasFormDraft(data)" class="has-link fl formDataEdit"
                                   ng-dialog="dashboard/views/dashboardSections/editObservationForm.html"
                                   ng-dialog-class="ngdialog-theme-default ng-dialog-all-details-page ng-dialog-edit"
                                   ng-dialog-data="{{getEditObsData(data)}}"
                                   ng-dialog-scope="this"
                                   ng-dialog-controller="EditObservationFormController"
                                   ng-dialog-pre-close-callback="directivePreCloseCallback">
+                                <i class="fa fa-pencil"></i>
+                            </span>
+                            <span ng-show="doesUserHaveAccessToTheForm(data, 'edit') && showEditForActiveEncounter(data.encounterUuid) && hasFormDraft(data)"
+                                  class="fl formDataEdit pencil-disabled">
                                 <i class="fa fa-pencil"></i>
                             </span>
                         </span>

--- a/ui/app/common/services/formDraftService.js
+++ b/ui/app/common/services/formDraftService.js
@@ -66,10 +66,30 @@ angular.module('bahmni.common.services')
             });
         };
 
+        var parseDraftObs = function (draftData) {
+            if (draftData && draftData.uuid && !draftData.markedAsSaved && draftData.formData) {
+                try {
+                    return angular.fromJson(draftData.formData);
+                } catch (e) { /* ignore */ }
+            }
+            return [];
+        };
+
+        var getFormNamesFromDraft = function (draftData) {
+            return _.uniq(_.compact(_.map(
+                _.filter(parseDraftObs(draftData), function (obs) {
+                    return obs.formNamespace === 'Bahmni' && obs.formFieldPath;
+                }),
+                function (obs) { return obs.formFieldPath.split('.')[0]; }
+            )));
+        };
+
         return {
             saveDraft: saveDraft,
             getDraft: getDraft,
             discardDraft: discardDraft,
-            markDraftAsSaved: markDraftAsSaved
+            markDraftAsSaved: markDraftAsSaved,
+            parseDraftObs: parseDraftObs,
+            getFormNamesFromDraft: getFormNamesFromDraft
         };
     }]);

--- a/ui/app/common/uicontrols/programmanagement/controllers/manageProgramController.js
+++ b/ui/app/common/uicontrols/programmanagement/controllers/manageProgramController.js
@@ -2,9 +2,9 @@
 
 angular.module('bahmni.common.uicontrols.programmanagment')
     .controller('ManageProgramController', ['$scope', 'retrospectiveEntryService', '$window', 'programService', '$translate',
-        'spinner', 'messagingService', '$stateParams', '$q', 'confirmBox', '$state', '$rootScope',
+        'spinner', 'messagingService', '$stateParams', '$q', 'confirmBox', '$state', '$rootScope', 'formDraftService',
         function ($scope, retrospectiveEntryService, $window, programService, $translate,
-            spinner, messagingService, $stateParams, $q, confirmBox, $state, $rootScope) {
+            spinner, messagingService, $stateParams, $q, confirmBox, $state, $rootScope, formDraftService) {
             var DateUtil = Bahmni.Common.Util.DateUtil;
             $scope.programSelected = {};
             $scope.workflowStateSelected = {};
@@ -30,8 +30,18 @@ angular.module('bahmni.common.uicontrols.programmanagment')
                 hasNoHierarchy: $scope.hasNoHierarchy,
                 patient: $scope.patient,
                 currentUser: $rootScope.currentUser,
-                currentProvider: $rootScope.currentProvider
+                currentProvider: $rootScope.currentProvider,
+                draftFormNames: formDraftService.getFormNamesFromDraft($rootScope.draftData)
             };
+
+            var cleanUpDraftWatch = $rootScope.$watch('draftData', function (newVal, oldVal) {
+                if (newVal === oldVal) { return; }
+                $scope.observationFormData.draftFormNames = formDraftService.getFormNamesFromDraft(newVal);
+            });
+
+            $scope.$on('$destroy', function () {
+                cleanUpDraftWatch();
+            });
 
             var updateActiveProgramsList = function () {
                 spinner.forPromise(programService.getPatientPrograms($scope.patient.uuid).then(function (programs) {

--- a/ui/app/styles/clinical/_visit.scss
+++ b/ui/app/styles/clinical/_visit.scss
@@ -126,6 +126,7 @@
             .pencil-disabled {
                 opacity: 0.4;
                 cursor: not-allowed;
+                pointer-events: none;
             }
 
             @media screen and (max-width: 1024px) {

--- a/ui/app/styles/clinical/_visit.scss
+++ b/ui/app/styles/clinical/_visit.scss
@@ -123,6 +123,11 @@
                 padding: 0 !important;
             }
 
+            .pencil-disabled {
+                opacity: 0.4;
+                cursor: not-allowed;
+            }
+
             @media screen and (max-width: 1024px) {
                 width: 214px;
             }

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -901,6 +901,23 @@ describe('ConceptSetPageController', function () {
             expect(broadcastSpy).toHaveBeenCalledWith('draft:saved', {draftDate: '08 Apr 2026', draftTime: '10:30 AM'});
         });
 
+        it('should update $rootScope.draftData after successful save so formsTable watch fires', function () {
+            var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
+            mockConceptSetService(conceptResponseData);
+            mockformService({});
+
+            var saveDraftPromise = specUtil.createServicePromise('saveDraft');
+            formDraftService.saveDraft.and.returnValue(saveDraftPromise);
+
+            createControllerWithTimeoutAndFilter();
+            scope.saveAsDraft();
+
+            var savedDraftData = {timestamp: Date.now(), uuid: 'draft-uuid', formData: '[]', markedAsSaved: false};
+            saveDraftPromise.callThenCallBack({data: savedDraftData});
+
+            expect(rootScope.draftData).toBe(savedDraftData);
+        });
+
         it('should not save draft when there is no active visit', function () {
             var conceptResponseData = {results: [{setMembers: [{name: {name: 'abcd'}, uuid: 123}]}]};
             mockConceptSetService(conceptResponseData);
@@ -1636,6 +1653,32 @@ describe('ConceptSetPageController', function () {
 
                 var conceptSetTemplate = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
                 expect(conceptSetTemplate.observations.length).toBe(1);
+            });
+
+            it('should merge draft values into existing saved observations for a previously saved form', function () {
+                var conceptUuid = 'concept-uuid-saved-form';
+                var fieldUuid = 'field-concept-uuid';
+                var conceptResponseData = {results: [{setMembers: [{name: {name: 'Saved Form'}, uuid: conceptUuid}]}]};
+                mockConceptSetService(conceptResponseData);
+                mockformService({});
+                enableDraftFeature();
+
+                scope.patient = {uuid: 'test-patient-uuid'};
+                rootScope.currentProvider = {uuid: 'test-provider-uuid'};
+                rootScope.resumeDraftOnLoad = false;
+                rootScope.currentUser = {isFavouriteObsTemplate: function () { return false; }};
+
+                var savedObs = {concept: {uuid: conceptUuid}, groupMembers: [{concept: {uuid: fieldUuid}, value: 'savedValue'}]};
+                scope.consultation.observations = [savedObs];
+
+                var draftObs = [{concept: {uuid: conceptUuid}, groupMembers: [{concept: {uuid: fieldUuid}, value: 'draftValue'}]}];
+                mockDraftSuccess({uuid: 'draft-uuid', markedAsSaved: false, formData: angular.toJson(draftObs)});
+
+                createControllerWithTimeoutAndFilter(timeoutMock);
+
+                var conceptSetTemplate = _.find(scope.allTemplates, function (t) { return t.uuid === conceptUuid; });
+                expect(conceptSetTemplate.hasUnsavedFormObservations).toBe(true);
+                expect(conceptSetTemplate.observations[0].groupMembers[0].value).toBe('draftValue');
             });
 
             it('should auto-populate Form2 forms when unsaved draft is found on direct navigation', function () {

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -1115,6 +1115,7 @@ describe('ConceptSetPageController', function () {
             scope.formDraft.statusError = true;
             scope.formDraft.showSpinner = true;
 
+            rootScope.draftData = {uuid: 'draft-uuid', markedAsSaved: false, formData: '[]'};
             rootScope.$broadcast('event:save-successful');
 
             expect(scope.formDraft.isDirty).toBe(false);
@@ -1125,6 +1126,7 @@ describe('ConceptSetPageController', function () {
             expect(scope.formDraft.statusMessage).toBeNull();
             expect(scope.formDraft.statusParams).toEqual({});
             expect(scope.formDraft.statusError).toBe(false);
+            expect(rootScope.draftData).toBeNull();
         });
 
         it('should ignore drafts that are already marked as saved when checking existing drafts', function () {

--- a/ui/test/unit/common/displaycontrols/dashboard/Directives/dashboard.spec.js
+++ b/ui/test/unit/common/displaycontrols/dashboard/Directives/dashboard.spec.js
@@ -26,7 +26,8 @@ describe('Dashboard', function () {
         $provide.value('messagingService', {});
         $provide.value('$state', {});
         $provide.value('$translate', {});
-        $provide.value('formPrintService',formPrintService);
+        $provide.value('formPrintService', formPrintService);
+        $provide.value('formDraftService', {getFormNamesFromDraft: function () { return []; }});
         $provide.value('configurations', {
             dosageFrequencyConfig: function () {
                 return {

--- a/ui/test/unit/common/displaycontrols/forms/directives/formsTable.spec.js
+++ b/ui/test/unit/common/displaycontrols/forms/directives/formsTable.spec.js
@@ -23,12 +23,12 @@ describe("Forms Table display control", function () {
         });
         formDraftService = {
             getDraft: getDraftSpy,
-            parseDraftObs: function (draftData) {
+            parseDraftObs: jasmine.createSpy('parseDraftObs').and.callFake(function (draftData) {
                 if (draftData && draftData.uuid && !draftData.markedAsSaved && draftData.formData) {
                     try { return angular.fromJson(draftData.formData); } catch (e) {}
                 }
                 return [];
-            }
+            })
         };
         spinner = jasmine.createSpyObj('spinner', ['forPromise']);
         ngDialog = jasmine.createSpyObj('ngDialog', ['open']);
@@ -561,6 +561,19 @@ describe("Forms Table display control", function () {
             expect(compiledElementScope.hasFormDraft(observation)).toBe(false);
         });
 
+        it("should return false when data has no concept", function () {
+            mockConceptSetService(allObsTemplateData);
+            mockVisitFormService(formDataObj);
+
+            var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft({uuid: "obs-without-concept"})).toBe(false);
+        });
+
         it("should return true when draft exists for the same form concept", function () {
             var draftFormData = angular.toJson([{concept: {uuid: "form-concept-uuid-1"}}]);
             rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: false, formData: draftFormData};
@@ -607,7 +620,7 @@ describe("Forms Table display control", function () {
             expect(compiledElementScope.hasFormDraft(observation)).toBe(false);
         });
 
-        it("should re-enable edit when draftData is cleared after save", function () {
+        it("should re-enable edit when draft is marked as saved (consultation submitted)", function () {
             rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: false, formData: angular.toJson([{concept: {uuid: "form-concept-uuid-1"}}])};
 
             mockConceptSetService(allObsTemplateData);
@@ -621,7 +634,7 @@ describe("Forms Table display control", function () {
 
             expect(compiledElementScope.hasFormDraft(observation)).toBe(true);
 
-            rootScope.draftData = null;
+            rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: true, formData: angular.toJson([{concept: {uuid: "form-concept-uuid-1"}}])};
             scope.$digest();
 
             expect(compiledElementScope.hasFormDraft(observation)).toBe(false);

--- a/ui/test/unit/common/displaycontrols/forms/directives/formsTable.spec.js
+++ b/ui/test/unit/common/displaycontrols/forms/directives/formsTable.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe("Forms Table display control", function () {
-    var element, scope, $compile, mockBackend, conceptSetService, visitFormService, q, spinner, formService, rootScope, ngDialog;
+    var element, scope, $compile, mockBackend, conceptSetService, visitFormService, q, spinner, formService, formDraftService, rootScope, ngDialog;
     var appService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
 
     appService.getAppDescriptor.and.returnValue({
@@ -18,6 +18,18 @@ describe("Forms Table display control", function () {
         conceptSetService = jasmine.createSpyObj('conceptSetService', ['getConcept', '']);
         visitFormService = jasmine.createSpyObj('visitFormService', ['formData']);
         formService = jasmine.createSpyObj('formService', ['getAllPatientForms', 'getFormList']);
+        var getDraftSpy = jasmine.createSpy('getDraft').and.callFake(function () {
+            return {then: function (callback) { return callback({data: null}); }};
+        });
+        formDraftService = {
+            getDraft: getDraftSpy,
+            parseDraftObs: function (draftData) {
+                if (draftData && draftData.uuid && !draftData.markedAsSaved && draftData.formData) {
+                    try { return angular.fromJson(draftData.formData); } catch (e) {}
+                }
+                return [];
+            }
+        };
         spinner = jasmine.createSpyObj('spinner', ['forPromise']);
         ngDialog = jasmine.createSpyObj('ngDialog', ['open']);
 
@@ -33,6 +45,7 @@ describe("Forms Table display control", function () {
         $provide.value('conceptSetService', conceptSetService);
         $provide.value('visitFormService', visitFormService);
         $provide.value('formService', formService);
+        $provide.value('formDraftService', formDraftService);
         $provide.value('spinner', spinner);
         $provide.value('ngDialog', ngDialog);
 
@@ -57,6 +70,7 @@ describe("Forms Table display control", function () {
         mockBackend = $httpBackend;
         mockBackend.expectGET('../common/displaycontrols/forms/views/formsTable.html').respond("<div>dummy</div>");
         rootScope.currentUser = jasmine.createSpyObj('currentUser', ['userProperties']);
+        rootScope.currentProvider = {uuid: 'provider-uuid-123'};
     }));
 
     var mockConceptSetService = function (data) {
@@ -521,6 +535,119 @@ describe("Forms Table display control", function () {
             expect(compiledElementScope.getDisplayName(observation)).toEqual(observation.concept.displayString);
         });
     });
+    describe("hasFormDraft", function () {
+        var allObsTemplateData = {"data": {"results": [{}]}};
+        var formDataObj = {"data": {results: []}};
+        var observation = {
+            "uuid": "obs-uuid-1",
+            "concept": {
+                "uuid": "form-concept-uuid-1",
+                "displayString": "Medication log Template",
+                "names": [],
+                "name": {name: "Medication log Template"}
+            }
+        };
+
+        it("should return false when there is no draft", function () {
+            mockConceptSetService(allObsTemplateData);
+            mockVisitFormService(formDataObj);
+
+            var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(false);
+        });
+
+        it("should return true when draft exists for the same form concept", function () {
+            var draftFormData = angular.toJson([{concept: {uuid: "form-concept-uuid-1"}}]);
+            rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: false, formData: draftFormData};
+
+            mockConceptSetService(allObsTemplateData);
+            mockVisitFormService(formDataObj);
+
+            var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(true);
+        });
+
+        it("should return false when draft exists for a different form concept", function () {
+            rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: false, formData: angular.toJson([{concept: {uuid: "different-concept-uuid"}}])};
+
+            mockConceptSetService(allObsTemplateData);
+            mockVisitFormService(formDataObj);
+
+            var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(false);
+        });
+
+        it("should return false when draft is marked as saved", function () {
+            rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: true, formData: angular.toJson([{concept: {uuid: "form-concept-uuid-1"}}])};
+
+            mockConceptSetService(allObsTemplateData);
+            mockVisitFormService(formDataObj);
+
+            var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(false);
+        });
+
+        it("should re-enable edit when draftData is cleared after save", function () {
+            rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: false, formData: angular.toJson([{concept: {uuid: "form-concept-uuid-1"}}])};
+
+            mockConceptSetService(allObsTemplateData);
+            mockVisitFormService(formDataObj);
+
+            var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(true);
+
+            rootScope.draftData = null;
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(false);
+        });
+
+        it("should re-enable edit when draft is discarded", function () {
+            rootScope.draftData = {uuid: "draft-uuid", markedAsSaved: false, formData: angular.toJson([{concept: {uuid: "form-concept-uuid-1"}}])};
+
+            mockConceptSetService(allObsTemplateData);
+            mockVisitFormService(formDataObj);
+
+            var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(true);
+
+            rootScope.draftData = null;
+            scope.$digest();
+
+            expect(compiledElementScope.hasFormDraft(observation)).toBe(false);
+        });
+    });
+
     describe('versioned form controller', function () {
         it('should return versionedFormController when section type is formsV2', function () {
             var simpleHtml = '<forms-table section="section" patient="patient" is-on-dashboard="false"></forms-table>';

--- a/ui/test/unit/common/uicontrols/programmanagement/controllers/manageProgramController.spec.js
+++ b/ui/test/unit/common/uicontrols/programmanagement/controllers/manageProgramController.spec.js
@@ -77,6 +77,7 @@ describe("ManageProgramController", function () {
         $provide.value('retrospectiveEntryService', retrospectiveEntryService);
         $provide.value('$stateParams', { configName: "default" });
         $provide.value('$translate', translate);
+        $provide.value('formDraftService', {getFormNamesFromDraft: function () { return []; }});
     }));
 
     beforeEach(inject(function ($controller, $rootScope, $q) {


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=AD3CuZpNJpfKsLymG

**Claude PR review:**
-> Null dereference in `hasFormDraft(data)` when `data.concept` is undefined
**Issue**:
`$scope.hasFormDraft` accesses `data.concept.uuid` without guarding against `data.concept` being `undefined`. The template calls this function for every item in the forms list. If any entry from the API lacks a `concept` property (malformed response, new form type), this throws `TypeError: Cannot read property 'uuid' of undefined` and breaks the entire forms display for that visit.

-> `event:save-successful` path doesn't clear `$rootScope.draftData` — Scenario 3 edge case
**Issue**:
AC Scenario 3 requires that the Edit button re-enables after the draft is submitted or discarded. The standard save path (via `consultationController`) and the discard path (via `patientDashboardController`) both set `$rootScope.draftData = null`. However, the `event:save-successful` listener in `conceptSetPageController.js` clears draft status flags but does not set `$rootScope.draftData = null`. This means in edge-case flows (save-via-event rather than full consultation save), the disabled pencil icon can remain stuck after the draft is resolved.

->  Two identical duplicate tests in `formsTable.spec.js`
**Issue**:
`"should re-enable edit when draftData is cleared after save"` and `"should re-enable edit when draft is discarded"` have byte-for-byte identical setup and assertions. Both set `rootScope.draftData = null` directly. This gives a false sense that the save and discard code paths are independently tested — neither path is actually exercised.

-> Missing test: `hasFormDraft` when `data.concept` is undefined
**Issue**:
The `hasFormDraft` test suite covers: no draft, matching concept, different concept, markedAsSaved, cleared draft. It does not cover `data.concept` being undefined — the exact case that triggers the CRITICAL null dereference in issue #3. This gap means CI passes while the bug ships.

->`parseDraftObs` implementation duplicated verbatim in test mock
**Issue**:
The test mock re-implements `parseDraftObs` as a live function with the exact same logic from `formDraftService.js`. If the real implementation changes (e.g., the `markedAsSaved` check), tests will silently keep passing against the stale copy. The `getDraft` spy in the same mock correctly uses `jasmine.createSpy` — `parseDraftObs` should follow that pattern.