### PR TITLE
117251: Fix units field disabled state for intraday variable frequency

### DIFF
--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -161,7 +161,7 @@
                             </div>
                             <div class="field-value">
                                 <select id="variable-dose-unit" class=" freq-dose-units" ng-model="treatment.variableDosingType.doseUnits"
-                                        ng-options="item.name as item.name for item in treatmentConfig.getDoseUnits()"
+                                        ng-options="item.name as item.name for item in getFinalDosingUnits(treatment)"
                                         ng-disabled="isRuleMode(treatment)"
                                         required="required">
                                     <option value="">{{ ::treatmentConfig.translate('doseUnitsPlaceHolder', 'MEDICATION_DOSE_UNIT_PLACEHOLDER') }} </option>

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -162,6 +162,7 @@
                             <div class="field-value">
                                 <select id="variable-dose-unit" class=" freq-dose-units" ng-model="treatment.variableDosingType.doseUnits"
                                         ng-options="item.name as item.name for item in treatmentConfig.getDoseUnits()"
+                                        ng-disabled="isRuleMode(treatment)"
                                         required="required">
                                     <option value="">{{ ::treatmentConfig.translate('doseUnitsPlaceHolder', 'MEDICATION_DOSE_UNIT_PLACEHOLDER') }} </option>
                                 </select>


### PR DESCRIPTION
## Summary

- Fix: variable dose units field (`variable-dose-unit`) was missing `ng-disabled="isRuleMode(treatment)"`, causing the units input to remain editable when dosing rule `ml/kg` is selected in variable/intraday frequency mode. The uniform dose units field already had this guard; now both modes are consistent.

## Test plan

- [ ] Select a drug, switch to variable frequency mode, set dosing rule to `ml/kg` — verify units field is disabled (auto-calculated)
- [ ] In uniform frequency mode with `ml/kg` rule — verify units field remains disabled (unchanged behaviour)
- [ ] In variable frequency mode without a dosing rule — verify units field is editable
- [ ] All existing tests pass: `yarn test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)