### PR TITLE
HIVE-113267: Fix nutrivalues latest obs hidden after order linkage

### DIFF
--- a/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
+++ b/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
@@ -121,7 +121,7 @@ angular.module('bahmni.common.displaycontrol.observation')
                             } else {
                                 $scope.initialization = observationsService.fetch($scope.patient.uuid, $scope.config.conceptNames,
                                     $scope.config.scope, $scope.config.numberOfVisits, $scope.visitUuid,
-                                    $scope.config.obsIgnoreList, null).then(function (response) {
+                                    $scope.config.obsIgnoreList, $scope.config.filterObsWithOrders).then(function (response) {
                                         mapObservation(response.data, $scope.config);
                                     });
                             }

--- a/ui/app/registration/views/visit.html
+++ b/ui/app/registration/views/visit.html
@@ -41,7 +41,7 @@
                                     <form-controls form="conceptSet" patient="patient" validate-form="true"></form-controls>
                                 </article>
                                 <article ng-if="::conceptSet.options.showLatest" class="obs-section fr" id="observationSection">
-                                    <bahmni-observation patient="patient" config="{conceptNames: conceptSet.options.conceptNames, scope: 'latest'}" section-title="'REGISTRATON_LATEST_KEY'"></bahmni-observation>
+                                    <bahmni-observation patient="patient" config="{conceptNames: conceptSet.options.conceptNames, scope: 'latest', filterObsWithOrders: false}" section-title="'REGISTRATON_LATEST_KEY'"></bahmni-observation>
                                 </article>
                             </div>
                         </div>

--- a/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
+++ b/ui/test/unit/common/displaycontrols/observation/directives/bahmniObservation.spec.js
@@ -117,10 +117,28 @@ describe("BahmniObservation", function () {
             expect(compiledElementScope).not.toBeUndefined();
             expect(compiledElementScope.config).not.toBeUndefined();
             expect(observationsService.fetch).toHaveBeenCalledWith(scope.patient.uuid, scope.config.conceptNames, scope.config.scope,
-                scope.config.numberOfVisits, undefined, undefined, null);
+                scope.config.numberOfVisits, undefined, undefined, undefined);
             expect(observationsService.fetch.calls.count()).toEqual(1);
             expect(observationsService.fetchForEncounter.calls.count()).toEqual(0);
             expect(observationsService.fetchForPatientProgram.calls.count()).toEqual(0);
+        });
+
+        it("should pass filterObsWithOrders from config to observationsService", function () {
+            scope.patient = {uuid: '123'};
+            scope.config = {showGroupDateTime: false, conceptNames: ["Height", "Weight"], scope: "latest", numberOfVisits: 1, filterObsWithOrders: false};
+            scope.section = {};
+            observationsService.fetch.and.returnValue(specUtil.respondWithPromise(q, {data: {}}));
+
+            mockBackend.expectGET('../common/displaycontrols/observation/views/observationDisplayControl.html').respond("<div>dummy</div>");
+
+            var element = $compile(simpleHtml)(scope);
+            scope.$digest();
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(observationsService.fetch).toHaveBeenCalledWith(scope.patient.uuid, scope.config.conceptNames, scope.config.scope,
+                scope.config.numberOfVisits, undefined, undefined, false);
+            expect(observationsService.fetch.calls.count()).toEqual(1);
         });
 
         it("should fetch observations within daterange if you want to fetch program specific data.", function () {
@@ -153,7 +171,7 @@ describe("BahmniObservation", function () {
             expect(compiledElementScope).not.toBeUndefined();
             expect(compiledElementScope.config).not.toBeUndefined();
             expect(observationsService.fetch).toHaveBeenCalledWith(scope.patient.uuid, scope.config.conceptNames,
-                scope.config.scope, scope.config.numberOfVisits, undefined, undefined, null);
+                scope.config.scope, scope.config.numberOfVisits, undefined, undefined, undefined);
             expect(observationsService.fetch.calls.count()).toEqual(1);
             expect(observationsService.fetchForEncounter.calls.count()).toEqual(0);
             expect(observationsService.fetchForPatientProgram.calls.count()).toEqual(0);


### PR DESCRIPTION
## Summary
- After HIVE-113267 linked general orders to height/weight obs on save, the registration nutrivalues \"Latest\" panel stopped showing those obs
- Root cause: `bahmniObservation.js` hardcoded `null` for `filterObsWithOrders`, so the backend defaulted to `true` → `obs.order.orderId is null` HQL filter excluded the newly order-linked obs
- Fix: made `bahmniObservation` read `filterObsWithOrders` from its config; set it to `false` in the registration visit latest panel so all obs are returned regardless of order linkage

## Changes
- `ui/app/common/displaycontrols/observation/directives/bahmniObservation.js` — pass `$scope.config.filterObsWithOrders` instead of hardcoded `null` to `observationsService.fetch`
- `ui/app/registration/views/visit.html` — add `filterObsWithOrders: false` to the `bahmni-observation` config for the showLatest panel

## Test plan
- [ ] Save height/weight on the Nutritional Values page
- [ ] Verify the "Latest" panel immediately reflects the saved values
- [ ] Verify other `bahmni-observation` usages (clinical dashboard, etc.) are unaffected — they don't set `filterObsWithOrders` in config so backend continues to default to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)