### PR TITLE
Pooja | Bugfix-116474 | Bugfix for Issue #2

### DIFF
--- a/ui/app/clinical/consultation/services/formDirtyStateService.js
+++ b/ui/app/clinical/consultation/services/formDirtyStateService.js
@@ -27,11 +27,15 @@ angular.module('bahmni.clinical')
                 return;
             }
             if (obs.value !== null && obs.value !== undefined) {
-                var val = obs.value;
-                if (val && typeof val === 'object' && val.uuid) {
-                    values.push(val.uuid);
+                if (obs.voided) {
+                    values.push(null);
                 } else {
-                    values.push(val);
+                    var val = obs.value;
+                    if (val && typeof val === 'object' && val.uuid) {
+                        values.push(val.uuid);
+                    } else {
+                        values.push(val);
+                    }
                 }
             }
         };
@@ -178,7 +182,14 @@ angular.module('bahmni.clinical')
                                templateMember.concept.uuid === draftMember.concept.uuid;
                     });
                     if (matchedMember) {
-                        populateObservationValues(matchedMember, draftMember);
+                        if (draftMember.voided) {
+                            var memberIndex = templateObs.groupMembers.indexOf(matchedMember);
+                            if (memberIndex > -1) {
+                                templateObs.groupMembers.splice(memberIndex, 1);
+                            }
+                        } else {
+                            populateObservationValues(matchedMember, draftMember);
+                        }
                     }
                 });
             }

--- a/ui/app/clinical/consultation/services/formDirtyStateService.js
+++ b/ui/app/clinical/consultation/services/formDirtyStateService.js
@@ -182,14 +182,7 @@ angular.module('bahmni.clinical')
                                templateMember.concept.uuid === draftMember.concept.uuid;
                     });
                     if (matchedMember) {
-                        if (draftMember.voided) {
-                            var memberIndex = templateObs.groupMembers.indexOf(matchedMember);
-                            if (memberIndex > -1) {
-                                templateObs.groupMembers.splice(memberIndex, 1);
-                            }
-                        } else {
-                            populateObservationValues(matchedMember, draftMember);
-                        }
+                        populateObservationValues(matchedMember, draftMember);
                     }
                 });
             }

--- a/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
+++ b/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
@@ -73,6 +73,51 @@ describe('formDirtyStateService', function () {
             formDirtyStateService.collectObsValues(null, values);
             expect(values).toEqual([]);
         });
+
+        it('should push null for voided observation with a value (so removal is detectable as dirty)', function () {
+            var values = [];
+            var obs = {value: 'image-url', voided: true};
+            formDirtyStateService.collectObsValues(obs, values);
+            expect(values).toEqual([null]);
+        });
+
+        it('should collect value when observation is not voided', function () {
+            var values = [];
+            var obs = {value: 'image-url', voided: false};
+            formDirtyStateService.collectObsValues(obs, values);
+            expect(values).toEqual(['image-url']);
+        });
+
+        it('should detect dirty state when image is removed (voided) — upload then void on fresh form', function () {
+            var templates = [{observations: [{value: 'image-url', voided: undefined}]}];
+            var cleanState = formDirtyStateService.getObsValues(templates);  // '["image-url"]'
+
+            templates[0].observations[0].voided = true;
+            var afterVoidState = formDirtyStateService.getObsValues(templates);  // '[null]'
+
+            expect(afterVoidState).not.toEqual(cleanState);
+        });
+
+        it('should detect dirty state when image removed after save-as-draft (cleanState has url)', function () {
+            var templates = [{observations: [{value: 'image-url', voided: false}]}];
+            var cleanState = formDirtyStateService.getObsValues(templates);  // '["image-url"]'
+
+            templates[0].observations[0].voided = true;
+            var afterVoidState = formDirtyStateService.getObsValues(templates);  // '[null]'
+
+            expect(afterVoidState).not.toEqual(cleanState);
+        });
+
+        it('should restore clean state when image void is undone', function () {
+            var templates = [{observations: [{value: 'image-url', voided: false}]}];
+            var cleanState = formDirtyStateService.getObsValues(templates);
+
+            templates[0].observations[0].voided = true;
+            templates[0].observations[0].voided = false;
+            var afterUndoState = formDirtyStateService.getObsValues(templates);
+
+            expect(afterUndoState).toEqual(cleanState);
+        });
     });
 
     describe('getTemplateObservationsForDirtyTracking', function () {


### PR DESCRIPTION
Hive: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=t7R8crQGbvWqPSwpH&projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr

Changes made:
**collectObsValues: push null for voided observations**
Problem: When a user uploads an image and then removes it (clicking X sets obs.voided = true), the "Save as Draft" button stayed disabled.
Root cause: collectObsValues only tracked obs.value. After removal, obs.voided = true but obs.value still held the URL. So the tracked state was identical before and after removal, no change detected, button stayed disabled.

We need three distinguishable states:
- No image — obs.value is undefined, nothing is pushed → tracked as []
- Image uploaded — obs.value is "url", obs.voided is false, "url" is pushed → tracked as ["url"]                        
- Image removed — obs.value is "url", obs.voided is true, null is pushed → tracked as [null]   

[null] ≠ ["url"] ≠ [] — all three states are distinct. The $watch on getObsValues() detects the transition from ["url"] to [null] when the image is removed, and enables the button.
If we had simply excluded voided obs (pushing nothing), "image removed" and "no image" would both map to [] — making them indistinguishable when the user uploads then immediately removes without saving first.
