### PR TITLE
Sasi | Fix units auto population in dosage rule

### DIFF
--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -969,10 +969,20 @@ angular.module('bahmni.clinical')
                     $scope.ruleUnitsMap = medicationConfig.tabConfig.allMedicationTabConfig.orderSet.dosageRuleUnitsMap || {};
                 }
                 $scope.$watch('treatment.dosingRule', function (newRule) {
-                    if (!newRule) return;
+                    if (!newRule) {
+                        $scope.treatment.uniformDosingType.doseUnits = undefined;
+                        $scope.treatment.variableDosingType.doseUnits = undefined;
+                        $scope.treatment.quantityUnit = undefined;
+                        return;
+                    }
                     var ruleUnits = $scope.ruleUnitsMap[newRule];
                     if (ruleUnits && ruleUnits.length === 1) {
                         $scope.treatment.uniformDosingType.doseUnits = ruleUnits[0];
+                        $scope.treatment.quantityUnit = ruleUnits[0];
+                    }
+                    if (!$scope.treatment.isUniformDosingType() && ruleUnits && ruleUnits.length > 0 && ruleUnits[0]) {
+                        $scope.treatment.variableDosingType.doseUnits = ruleUnits[0];
+                        $scope.treatment.quantityUnit = ruleUnits[0];
                     }
                 });
             };

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -235,7 +235,7 @@
                             <div class="field-value">
                                 <select ng-if="!treatmentConfig.isHiddenField('quantityUnits')" id="total-quantity-unit"
                                         class="fl" ng-model="treatment.quantityUnit" ng-change="treatment.setQuantityUnitEnteredManually()"
-                                        ng-options="item.name as item.name for item in treatmentConfig.getDoseUnits()"
+                                        ng-options="item.name as item.name for item in getFinalDosingUnits(treatment)"
                                         ng-required="treatment.isDurationRequired">
                                     <option value="">{{ ::treatmentConfig.translate('quantityUnitsPlaceHolder', 'MEDICATION_CHOOSE_QUANTITY_UNIT_PLACEHOLDER') }} </option>
                                 </select>


### PR DESCRIPTION
Currently quantity units and dose units are auto populating correctly in the dosage rule flow with uniform dosage and intraday dose. These changes will fix the issue and also clear the units correctly upon dosage rule reset