### PR TITLE
HIVE-121034|Karthik|Suhas Separate patient image from navigation link for click-to-enlarge

### DIFF
--- a/ui/app/clinical/dashboard/views/clinicalDashboardHeader.html
+++ b/ui/app/clinical/dashboard/views/clinicalDashboardHeader.html
@@ -10,13 +10,15 @@
                 title="{{adtNavigationConfig.title}}">
                     <i class="fa fa-bed fa-white"></i>
                 </a>
-                <a class="back-btn-link" id="dashboard-link" accesskey="d" ng-click="gotoPatientDashboard()" title="Back to {{patient.name}} Dashboard">
-                    <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">
+                <div class="back-btn-link">
+                <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">    
+                <a id="dashboard-link" accesskey="d" ng-click="gotoPatientDashboard()" title="Back to {{patient.name}} Dashboard">
                 <span class="patient-info">
                     <span class="patient-name" >{{patient.name}} </span>
                     <span class="patient-id">{{patient.identifier}}</span>
                 </span>
                 </a>
+                </div>
             </div>
 
             <div class="header-scrollable-tabs header-tabs" ng-if="!stateChange()">

--- a/ui/app/orders/views/header.html
+++ b/ui/app/orders/views/header.html
@@ -1,6 +1,6 @@
 <div class="back-btn-link">
+    <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">
     <a ng-href="../clinical/#/default/patient/{{patient.uuid}}/dashboard" title="Back to {{patient.name}}'s Clinical Dashboard">
-        <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">
         <span class="patient-info">
             <span class="patient-name" >{{patient.name}} </span>
             <span class="patient-id">{{patient.identifier}}</span>


### PR DESCRIPTION
Move patient profile image outside the navigation link in clinical dashboard and orders headers to enable independent image interaction. This prepares the image element for click-to-enlarge functionality while keeping patient name/ID as the navigation trigger.

Hive card: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=2NgJLHL3Fn2ZnC9JR