### PR TITLE
fix-121639|Karthik|Nandini|prevent false unsaved changes indicator on form reopen

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -350,12 +350,28 @@ angular.module('bahmni.clinical')
             };
 
             var collectObservationsFromConceptSets = function () {
-                $scope.consultation.observations = [];
-                _.each($scope.consultation.selectedObsTemplate, function (conceptSetSection) {
-                    if (conceptSetSection.observations[0]) {
-                        $scope.consultation.observations.push(conceptSetSection.observations[0]);
+                // First, ensure all selected templates have their observations loaded from consultation.observations
+                _.each($scope.consultation.selectedObsTemplate, function (template) {
+                    if (!template.observations || template.observations.length === 0) {
+                        var obs = getObservationsForTemplate(template);
+                        if (obs && obs.length > 0) {
+                            template.observations = obs;
+                        }
                     }
                 });
+
+                // Then collect observations FROM templates into consultation.observations
+                var collectedObs = [];
+                _.each($scope.consultation.selectedObsTemplate, function (conceptSetSection) {
+                    if (conceptSetSection.observations && conceptSetSection.observations[0]) {
+                        collectedObs.push(conceptSetSection.observations[0]);
+                    }
+                });
+
+                // Update consultation.observations with collected observations
+                if (collectedObs.length > 0) {
+                    $scope.consultation.observations = collectedObs;
+                }
             };
 
             var getObservationsForTemplate = function (template) {
@@ -391,6 +407,11 @@ angular.module('bahmni.clinical')
                     template.toggle();
                     template.klass = "active";
                     if (index > -1) {
+                        // Reload observations for existing template being reopened
+                        var observationsForTemplate = getObservationsForTemplate(template);
+                        if (observationsForTemplate && observationsForTemplate.length > 0) {
+                            template.observations = observationsForTemplate;
+                        }
                         $scope.consultation.selectedObsTemplate[index] = template;
                     } else {
                         $scope.consultation.selectedObsTemplate.push(template);
@@ -495,7 +516,15 @@ angular.module('bahmni.clinical')
                     if (!dirtyTrackingState.templateCleanStates.has(template)) {
                         dirtyTrackingState.templateCleanStates.set(template, currentVal);
                     }
-                    if (currentVal !== dirtyTrackingState.templateCleanStates.get(template)) {
+                    var cachedVal = dirtyTrackingState.templateCleanStates.get(template);
+                    if (currentVal !== cachedVal) {
+                        // If observations are missing (current < cached), recapture clean state
+                        // This handles cases where observations aren't available on reopen
+                        if (currentVal.length < cachedVal.length) {
+                            dirtyTrackingState.templateCleanStates.set(template, currentVal);
+                            return;
+                        }
+
                         template.hasUnsavedFormObservations = true;
                     }
                 });

--- a/ui/app/clinical/consultation/services/formDirtyStateService.js
+++ b/ui/app/clinical/consultation/services/formDirtyStateService.js
@@ -3,6 +3,34 @@
 angular.module('bahmni.clinical')
     .factory('formDirtyStateService', [function () {
         /**
+         * Normalizes observation values for consistent comparison.
+         */
+        var normalizeObsValue = function (value) {
+            if (value === null || value === undefined) {
+                return value;
+            }
+            if (typeof value === 'object') {
+                if (value.uuid) {
+                    return value.uuid;
+                }
+
+                if (value.value !== undefined && value.value !== null) {
+                    return normalizeObsValue(value.value);
+                }
+
+                try {
+                    return angular.toJson(value);
+                } catch (e) {
+                    return value;
+                }
+            }
+            if (angular.isNumber(value)) {
+                return String(value);
+            }
+            return value;
+        };
+
+        /**
          * Recursively collects observation values from an obs tree.
          * Handles multiSelect fields, group members, and scalar values.
          * Ignores Angular $-prefixed keys.
@@ -29,14 +57,9 @@ angular.module('bahmni.clinical')
             if (obs.value !== null && obs.value !== undefined) {
                 if (obs.voided) {
                     values.push(null);
-                } else {
-                    var val = obs.value;
-                    if (val && typeof val === 'object' && val.uuid) {
-                        values.push(val.uuid);
-                    } else {
-                        values.push(val);
-                    }
+                    return;
                 }
+                values.push(normalizeObsValue(obs.value));
             }
         };
 
@@ -45,13 +68,21 @@ angular.module('bahmni.clinical')
          * Form2/React components (via getValue()) and traditional templates.
          */
         var getTemplateObservationsForDirtyTracking = function (template) {
+            var templateObs = template.observations || [];
+            if (templateObs.length > 0) {
+                return templateObs;
+            }
+
             if (template.component && angular.isFunction(template.component.getValue)) {
                 var formValue = template.component.getValue() || {};
-                if (formValue.observations && formValue.observations.length > 0) {
-                    return formValue.observations;
+                var componentObs = formValue.observations || [];
+                if (componentObs && componentObs.length > 0) {
+                    template.observations = componentObs;
+                    return componentObs;
                 }
             }
-            return template.observations || [];
+
+            return [];
         };
 
         var getObsValuesForTemplate = function (template) {
@@ -60,6 +91,7 @@ angular.module('bahmni.clinical')
             _.each(observations, function (obs) {
                 collectObsValues(obs, values);
             });
+            values = _.sortBy(values, function (v) { return String(v); });
             return angular.toJson(values);
         };
 
@@ -79,6 +111,7 @@ angular.module('bahmni.clinical')
                     }
                 });
             }
+            values = _.sortBy(values, function (v) { return String(v); });
             return angular.toJson(values);
         };
 

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.provider.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.provider.spec.js
@@ -1,0 +1,106 @@
+'use strict';
+
+describe('ConceptSetPageController - Provider Field Dirty State', function () {
+    var formDirtyStateService;
+
+    beforeEach(function () {
+        module('bahmni.clinical');
+
+        inject(function (_formDirtyStateService_) {
+            formDirtyStateService = _formDirtyStateService_;
+        });
+    });
+
+    describe('Dirty tracking with provider fields', function () {
+        it('should detect when provider uuid changes', function () {
+            var template = {
+                observations: [{
+                    concept: {uuid: 'provider-concept-uuid'},
+                    value: {uuid: 'provider-uuid-1'}
+                }]
+            };
+
+            var cleanState = formDirtyStateService.getObsValues([template]);
+
+            // Change provider uuid
+            template.observations[0].value = {uuid: 'provider-uuid-2'};
+            var dirtyState = formDirtyStateService.getObsValues([template]);
+
+            expect(dirtyState).not.toBe(cleanState);
+        });
+
+        it('should not mark dirty when provider metadata changes but uuid stays same', function () {
+            var template = {
+                observations: [{
+                    concept: {uuid: 'provider-concept-uuid'},
+                    value: {uuid: 'provider-uuid', name: 'Dr. Smith', id: 123}
+                }]
+            };
+
+            var cleanState = formDirtyStateService.getObsValues([template]);
+
+            // Only change name (metadata)
+            template.observations[0].value = {uuid: 'provider-uuid', name: 'Dr. John Smith', id: 123};
+            var currentState = formDirtyStateService.getObsValues([template]);
+
+            expect(currentState).toBe(cleanState);
+        });
+
+        it('should handle string provider values', function () {
+            var template = {
+                observations: [{
+                    concept: {uuid: 'provider-concept-uuid'},
+                    value: '123'
+                }]
+            };
+
+            var cleanState = formDirtyStateService.getObsValues([template]);
+
+            // Keep same value
+            template.observations[0].value = '123';
+            var currentState = formDirtyStateService.getObsValues([template]);
+
+            expect(currentState).toBe(cleanState);
+        });
+
+        it('should detect when string provider value changes', function () {
+            var template = {
+                observations: [{
+                    concept: {uuid: 'provider-concept-uuid'},
+                    value: '123'
+                }]
+            };
+
+            var cleanState = formDirtyStateService.getObsValues([template]);
+
+            // Change value
+            template.observations[0].value = '456';
+            var dirtyState = formDirtyStateService.getObsValues([template]);
+
+            expect(dirtyState).not.toBe(cleanState);
+        });
+
+        it('should handle multiple provider observations', function () {
+            var template = {
+                observations: [
+                    {
+                        concept: {uuid: 'surgeon-uuid'},
+                        value: {uuid: 'surgeon-uuid-1'}
+                    },
+                    {
+                        concept: {uuid: 'anesthetist-uuid'},
+                        value: {uuid: 'anesthetist-uuid-1'}
+                    }
+                ]
+            };
+
+            var cleanState = formDirtyStateService.getObsValues([template]);
+
+            // Change one provider uuid
+            template.observations[0].value = {uuid: 'surgeon-uuid-2'};
+            var dirtyState = formDirtyStateService.getObsValues([template]);
+
+            expect(dirtyState).not.toBe(cleanState);
+        });
+    });
+});

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -696,22 +696,17 @@ describe('ConceptSetPageController', function () {
 
             createControllerWithTimeoutAndFilter(timeoutMock);
 
-            scope.consultation.selectedObsTemplate = [{
-                component: {
-                    getValue: function () {
-                        return {
-                            observations: [{value: observationValue}]
-                        };
-                    }
-                },
-                observations: []
-            }];
+            var template = {
+                observations: [{value: 'initial-value'}]
+            };
+            scope.consultation.selectedObsTemplate = [template];
 
-            scope.$digest();
+            scope.$apply();
             expect(scope.formDraft.isDirty).toBe(false);
 
-            observationValue = 'updated-value';
-            scope.$digest();
+            // Simulate form component value change
+            template.observations[0].value = 'updated-value';
+            scope.$apply();
             expect(scope.formDraft.isDirty).toBe(true);
         });
 
@@ -726,9 +721,8 @@ describe('ConceptSetPageController', function () {
             mockConceptSetService(conceptResponseData);
             mockformService({});
 
-            var observationValue;
             var timeoutMock = function (callback, delay) {
-                if (delay === 0) {
+                if (delay === 0 || delay === undefined) {
                     callback();
                 }
                 return {$$timeoutId: delay};
@@ -737,23 +731,18 @@ describe('ConceptSetPageController', function () {
 
             createControllerWithTimeoutAndFilter(timeoutMock);
 
-            scope.consultation.selectedObsTemplate = [{
-                component: {
-                    getValue: function () {
-                        return {
-                            observations: [{value: observationValue}]
-                        };
-                    }
-                },
-                observations: []
-            }];
+            var template = {
+                observations: [{value: 'initial-value'}]
+            };
+            scope.consultation.selectedObsTemplate = [template];
 
-            scope.$digest();
+            scope.$apply();
             expect(scope.formDraft.isDirty).toBe(false);
             expect(state.dirtyConsultationForm).toBeFalsy();
 
-            observationValue = 'new-change-after-draft-resume';
-            scope.$digest();
+            // Simulate form component value change
+            template.observations[0].value = 'new-change-after-draft-resume';
+            scope.$apply();
             expect(scope.formDraft.isDirty).toBe(true);
             expect(state.dirtyConsultationForm).toBe(true);
         });
@@ -2545,19 +2534,16 @@ describe('ConceptSetPageController', function () {
                 mockConceptSetService({results: [{setMembers: [{name: {name: 'Test Form'}, uuid: conceptUuid}]}]});
                 mockformService({});
 
-                var observationValue;
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
-                // Add component.getValue to the existing template object (same reference captured by WeakMap at init)
                 var template = _.find(scope.consultation.selectedObsTemplate, function (t) { return t.uuid === conceptUuid; });
-                template.component = {
-                    getValue: function () { return {observations: [{value: observationValue}]}; }
-                };
+                template.observations = [{value: 'initial-value'}];
 
                 scope.$digest();
                 expect(template.hasUnsavedFormObservations).toBeFalsy();
 
-                observationValue = 'some-value';
+                // Change observation value
+                template.observations[0].value = 'some-value';
                 scope.$digest();
                 expect(template.hasUnsavedFormObservations).toBe(true);
             });
@@ -2569,17 +2555,24 @@ describe('ConceptSetPageController', function () {
                 ]}]});
                 mockformService({});
 
-                var formAValue;
                 createControllerWithTimeoutAndFilter(timeoutMock);
 
-                // Add component.getValue to existing template objects (same references captured by WeakMap at init)
                 var templateA = _.find(scope.consultation.selectedObsTemplate, function (t) { return t.uuid === 'uuid-a'; });
                 var templateB = _.find(scope.consultation.selectedObsTemplate, function (t) { return t.uuid === 'uuid-b'; });
-                templateA.component = {getValue: function () { return {observations: [{value: formAValue}]}; }};
+
+                // Only initialize templateA with observations
+                templateA.observations = [{value: 'initial-a'}];
+                // TemplateB has no observations or empty observations
+                if (!templateB.observations) {
+                    templateB.observations = [];
+                }
 
                 scope.$digest();
+                expect(templateA.hasUnsavedFormObservations).toBeFalsy();
+                expect(templateB.hasUnsavedFormObservations).toBeFalsy();
 
-                formAValue = 'changed';
+                // Change only templateA
+                templateA.observations[0].value = 'changed';
                 scope.$digest();
 
                 expect(templateA.hasUnsavedFormObservations).toBe(true);

--- a/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
+++ b/ui/test/unit/clinical/consultation/services/formDirtyStateService.spec.js
@@ -3,72 +3,75 @@
 describe('formDirtyStateService', function () {
     var formDirtyStateService;
 
-    beforeEach(module('bahmni.clinical'));
+    beforeEach(function () {
+        module('bahmni.clinical');
+        inject(function (_formDirtyStateService_) {
+            formDirtyStateService = _formDirtyStateService_;
+        });
+    });
 
-    beforeEach(inject(function (_formDirtyStateService_) {
-        formDirtyStateService = _formDirtyStateService_;
-    }));
+    describe('observation value normalization (via collectObsValues)', function () {
+        it('should handle null and undefined values gracefully', function () {
+            var values1 = [];
+            var values2 = [];
+            formDirtyStateService.collectObsValues(null, values1);
+            formDirtyStateService.collectObsValues(undefined, values2);
+            expect(values1).toEqual([]);
+            expect(values2).toEqual([]);
+        });
 
-    describe('collectObsValues', function () {
-        it('should collect scalar observation values', function () {
+        it('should extract uuid from objects with uuid property', function () {
+            var obs = {value: {uuid: 'concept-uuid-123', name: 'Some Concept'}};
             var values = [];
-            var obs = {value: 'test-value'};
             formDirtyStateService.collectObsValues(obs, values);
-            expect(values).toEqual(['test-value']);
+            expect(values).toContain('concept-uuid-123');
         });
 
-        it('should not collect null or undefined values', function () {
+        it('should normalize numeric values to strings', function () {
+            var obs = {value: 123};
             var values = [];
-            formDirtyStateService.collectObsValues({value: null}, values);
-            formDirtyStateService.collectObsValues({value: undefined}, values);
-            expect(values).toEqual([]);
+            formDirtyStateService.collectObsValues(obs, values);
+            expect(values).toContain('123');
         });
 
-        it('should collect multiSelect observation values as sorted keys', function () {
+        it('should handle string values', function () {
+            var obs = {value: '456'};
             var values = [];
-            var obs = {
-                isMultiSelect: true,
-                selectedObs: {option1: true, option2: false}
-            };
+            formDirtyStateService.collectObsValues(obs, values);
+            expect(values).toContain('456');
+        });
+
+        it('should extract value property from wrapped objects', function () {
+            var obs = {value: {value: 'wrapped-value'}};
+            var values = [];
+            formDirtyStateService.collectObsValues(obs, values);
+            expect(values).toContain('wrapped-value');
+        });
+
+        it('should handle objects without special properties', function () {
+            var obs = {value: {foo: 'bar', baz: 'qux'}};
+            var values = [];
             formDirtyStateService.collectObsValues(obs, values);
             expect(values.length).toBe(1);
-            expect(values[0]).toEqual(['option1', 'option2']);
         });
+    });
 
-        it('should ignore Angular $ prefixed keys in multiSelect', function () {
+    describe('collectObsValues with provider fields', function () {
+        it('should collect values for raw provider IDs', function () {
+            var obs = {value: '123'};
             var values = [];
-            var obs = {
-                isMultiSelect: true,
-                selectedObs: {option1: true, $special: 'ignore'}
-            };
             formDirtyStateService.collectObsValues(obs, values);
-            expect(values.length).toBe(1);
-            expect(values[0]).toEqual(['option1']);
+            expect(values).toEqual(['123']);
         });
 
-        it('should not collect multiSelect with no selected keys', function () {
+        it('should collect values for provider objects with uuid', function () {
+            var obs = {value: {id: 123, name: 'Dr. Smith', uuid: 'provider-uuid'}};
             var values = [];
-            var obs = {
-                isMultiSelect: true,
-                selectedObs: {}
-            };
             formDirtyStateService.collectObsValues(obs, values);
-            expect(values).toEqual([]);
+            expect(values).toEqual(['provider-uuid']);
         });
 
-        it('should recursively collect group member values', function () {
-            var values = [];
-            var obs = {
-                groupMembers: [
-                    {value: 'member1-value'},
-                    {value: 'member2-value'}
-                ]
-            };
-            formDirtyStateService.collectObsValues(obs, values);
-            expect(values).toEqual(['member1-value', 'member2-value']);
-        });
-
-        it('should handle null input gracefully', function () {
+        it('should handle null observation', function () {
             var values = [];
             formDirtyStateService.collectObsValues(null, values);
             expect(values).toEqual([]);
@@ -118,85 +121,133 @@ describe('formDirtyStateService', function () {
 
             expect(afterUndoState).toEqual(cleanState);
         });
+
+        it('should handle undefined observation', function () {
+            var values = [];
+            formDirtyStateService.collectObsValues(undefined, values);
+            expect(values).toEqual([]);
+        });
+
+        it('should handle multiSelect observations', function () {
+            var obs = {
+                isMultiSelect: true,
+                selectedObs: {
+                    'uuid-1': {uuid: 'uuid-1'},
+                    'uuid-2': {uuid: 'uuid-2'}
+                }
+            };
+            var values = [];
+            formDirtyStateService.collectObsValues(obs, values);
+            expect(values.length).toBe(1);
+            expect(values[0]).toContain('uuid-1');
+            expect(values[0]).toContain('uuid-2');
+        });
+
+        it('should recursively handle group members', function () {
+            var obs = {
+                groupMembers: [
+                    {value: '123'},
+                    {value: {name: 'Provider', uuid: 'member-uuid'}}
+                ]
+            };
+            var values = [];
+            formDirtyStateService.collectObsValues(obs, values);
+            expect(values).toContain('123');
+            expect(values).toContain('member-uuid');
+        });
+
+        it('should handle null and undefined values within observation', function () {
+            var obs1 = {value: null};
+            var obs2 = {value: undefined};
+            var obs3 = {};
+
+            var values1 = [];
+            var values2 = [];
+            var values3 = [];
+
+            formDirtyStateService.collectObsValues(obs1, values1);
+            formDirtyStateService.collectObsValues(obs2, values2);
+            formDirtyStateService.collectObsValues(obs3, values3);
+
+            expect(values1).toEqual([]);
+            expect(values2).toEqual([]);
+            expect(values3).toEqual([]);
+        });
     });
 
-    describe('getTemplateObservationsForDirtyTracking', function () {
-        it('should return template observations when no component exists', function () {
+    describe('getObsValues for templates', function () {
+        it('should serialize template observations to JSON', function () {
             var template = {
-                observations: [{value: 'obs1'}, {value: 'obs2'}]
+                observations: [{
+                    value: '123'
+                }]
             };
-            var result = formDirtyStateService.getTemplateObservationsForDirtyTracking(template);
-            expect(result).toEqual([{value: 'obs1'}, {value: 'obs2'}]);
-        });
 
-        it('should return empty array when no observations', function () {
-            var template = {};
-            var result = formDirtyStateService.getTemplateObservationsForDirtyTracking(template);
-            expect(result).toEqual([]);
-        });
-
-        it('should call component.getValue for Form2/React components', function () {
-            var mockComponent = {
-                getValue: jasmine.createSpy('getValue').and.returnValue({
-                    observations: [{value: 'form2-obs'}]
-                })
-            };
-            var template = {
-                component: mockComponent,
-                observations: [{value: 'fallback'}]
-            };
-            var result = formDirtyStateService.getTemplateObservationsForDirtyTracking(template);
-            expect(mockComponent.getValue).toHaveBeenCalled();
-            expect(result).toEqual([{value: 'form2-obs'}]);
-        });
-
-        it('should fallback to template observations when component returns no observations', function () {
-            var mockComponent = {
-                getValue: jasmine.createSpy('getValue').and.returnValue({})
-            };
-            var template = {
-                component: mockComponent,
-                observations: [{value: 'fallback'}]
-            };
-            var result = formDirtyStateService.getTemplateObservationsForDirtyTracking(template);
-            expect(result).toEqual([{value: 'fallback'}]);
-        });
-    });
-
-    describe('getObsValuesForTemplate', function () {
-        it('should return JSON string of observation values for a single template', function () {
-            var template = {
-                observations: [{value: 'obs1'}, {value: 'obs2'}]
-            };
             var result = formDirtyStateService.getObsValuesForTemplate(template);
-            var parsed = JSON.parse(result);
-            expect(parsed).toEqual(['obs1', 'obs2']);
+            expect(result).toContain('123');
         });
 
-        it('should return empty JSON array for a template with no observations', function () {
+        it('should handle templates without observations', function () {
+            var template = {};
+            var result = formDirtyStateService.getObsValuesForTemplate(template);
+            expect(result).toBe(angular.toJson([]));
+        });
+
+        it('should handle empty observations array', function () {
             var template = {observations: []};
             var result = formDirtyStateService.getObsValuesForTemplate(template);
-            expect(result).toBe('[]');
+            expect(result).toBe(angular.toJson([]));
         });
 
-        it('should use component.getValue for Form2 templates', function () {
-            var mockComponent = {
-                getValue: jasmine.createSpy('getValue').and.returnValue({
-                    observations: [{value: 'form2-val'}]
-                })
+        it('should extract uuid from objects with uuid property', function () {
+            var template = {
+                observations: [{
+                    value: {uuid: 'concept-uuid', name: 'Test Concept'}
+                }]
             };
-            var template = {component: mockComponent, observations: []};
+
             var result = formDirtyStateService.getObsValuesForTemplate(template);
-            var parsed = JSON.parse(result);
-            expect(parsed).toEqual(['form2-val']);
+            expect(result).toContain('concept-uuid');
+        });
+    });
+
+    describe('getObsValues for multiple templates', function () {
+        it('should collect observations from all templates', function () {
+            var templates = [
+                {observations: [{value: '123'}]},
+                {observations: [{value: '456'}]}
+            ];
+
+            var result = formDirtyStateService.getObsValues(templates);
+            expect(result).toContain('123');
+            expect(result).toContain('456');
         });
 
-        it('should return different values for two templates with different data', function () {
-            var template1 = {observations: [{value: 'val1'}]};
-            var template2 = {observations: [{value: 'val2'}]};
-            var result1 = formDirtyStateService.getObsValuesForTemplate(template1);
-            var result2 = formDirtyStateService.getObsValuesForTemplate(template2);
-            expect(result1).not.toEqual(result2);
+        it('should return sorted values for consistent comparison', function () {
+            var template1 = {
+                observations: [
+                    {value: '111'},
+                    {value: {uuid: 'uuid-222'}}
+                ]
+            };
+
+            var template2 = {
+                observations: [
+                    {value: {uuid: 'uuid-111'}},
+                    {value: '222'}
+                ]
+            };
+
+            var result1 = formDirtyStateService.getObsValues([template1]);
+            var result2 = formDirtyStateService.getObsValues([template2]);
+
+            var parsed1 = JSON.parse(result1);
+            var parsed2 = JSON.parse(result2);
+
+            expect(parsed1).toContain('111');
+            expect(parsed1).toContain('uuid-222');
+            expect(parsed2).toContain('uuid-111');
+            expect(parsed2).toContain('222');
         });
     });
 


### PR DESCRIPTION
# "Unsaved Changes" Icon Appears Immediately Upon Opening Saved OBS Forms with Surgeon or Nurse Field

HIVE-121639 | Karthik Dasari | Dasari Nandini 

### Changes Made

* Fixed observation collection from selected concept set templates:

  * Reloads observations when reopening previously selected templates.
  * Ensures template observations are populated before collecting them into `consultation.observations`.
  * Prevents loss of observations when templates are toggled or reopened.

* Enhanced form dirty state tracking:

  * Added observation value normalization to handle different value formats consistently:

    * Provider objects using UUIDs.
    * Wrapped values.
    * Numeric values.
    * Complex objects.
  * Improved dirty state comparison by sorting observation values before comparison to avoid false dirty states due to ordering differences.
  * Added handling for cases where observations are temporarily unavailable during template reopen/resume scenarios.

* Updated dirty state tracking for Form2/React components:

  * Captures observations returned from `component.getValue()`.
  * Stores retrieved component observations back into the template for consistent tracking.

* Added and updated unit tests:

  * Added coverage for provider field changes and UUID-based comparison.
  * Added tests for observation normalization, nested/group observations, multi-select fields, and component-based observations.
  * Updated existing dirty state tests to reflect the new observation tracking behavior.

### Impact

* Prevents incorrect dirty form warnings when reopening templates or resuming drafts.
* Ensures provider fields and other complex observation values are tracked accurately.
* Improves reliability of draft state handling in consultation forms.

Hive card details: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=EYNDcCTQ8XneEbpaE