### PR TITLE
bugfix-121640|Karthik|Nandini|clean up deleted form state and validation

### DIFF
--- a/ui/app/common/concept-set/directives/conceptSetGroup.js
+++ b/ui/app/common/concept-set/directives/conceptSetGroup.js
@@ -116,17 +116,37 @@ angular.module('bahmni.common.conceptSet')
             $scope.remove = function (index) {
                 var label = $scope.allTemplates[index].label;
                 var currentTemplate = $scope.allTemplates[index];
+                if (currentTemplate.component) {
+                    currentTemplate.component = null;
+                }
                 var anotherTemplate = _.find($scope.allTemplates, function (template) {
                     return template.label == currentTemplate.label && template !== currentTemplate;
                 });
-                if (anotherTemplate) {
+                var isObservationForm = currentTemplate.formUuid;
+                if (isObservationForm) {
+                    var formIndex = _.findIndex($scope.consultation.observationForms, function (form) {
+                        return form === currentTemplate;
+                    });
+                    if (formIndex > -1) {
+                        $scope.consultation.observationForms.splice(formIndex, 1);
+                    }
                     $scope.allTemplates.splice(index, 1);
+                }
+                else if (anotherTemplate) {
+                    $scope.allTemplates.splice(index, 1);
+                    var selectedIndex = _.findIndex($scope.consultation.selectedObsTemplate, function (template) {
+                        return template === currentTemplate;
+                    });
+                    if (selectedIndex > -1) {
+                        $scope.consultation.selectedObsTemplate.splice(selectedIndex, 1);
+                    }
                 }
                 else {
                     $scope.allTemplates[index].isAdded = false;
                     var clonedObj = $scope.allTemplates[index].clone();
                     $scope.allTemplates[index] = clonedObj;
-                    $scope.allTemplates[index].isAdded = false;
+                    $scope.allTemplates[index].hasUnsavedFormObservations = false;
+                    $scope.allTemplates[index].draftValidationPassed = undefined;
                     $scope.allTemplates[index].isOpen = false;
                     $scope.allTemplates[index].klass = "";
                     $scope.allTemplates[index].isLoaded = false;


### PR DESCRIPTION
## Form Deletion Causes UI Anomaly (Empty Row) and Blocks Saving via Phantom Validation

HiVE-121640| Karthik Dasari | Dasari Nandini

## Changes made
- Fixed the UI issue where deleting the **Fall Risk** form left behind an empty row that could be clicked to restore the deleted form.
- Updated the deletion behavior to consistently remove the form from the active view (or reset it to its default un-entered state, matching other Observation forms).
- Cleared form-specific validation state when a form is deleted to prevent mandatory field validations from persisting after removal.
- Resolved the issue where validation from a deleted form blocked saving other Observation forms, eliminating the need to refresh the page.

## Issues Addressed

### UI Glitch on Deletion
- Deleting a form no longer leaves an empty placeholder row.
- The deleted form cannot be restored by clicking the previously occupied row.

### Phantom Validation
- Validation rules for deleted forms are removed from the active session.
- Saving other Observation forms is no longer blocked by validation errors from deleted forms.

## Testing
- Verified that deleting the **Fall Risk** form removes it cleanly without leaving an empty row.
- Verified that clicking the previously occupied area does not restore the deleted form.
- Verified that deleting an incomplete form clears its validation state.
- Verified that users can successfully save other Observation forms after deleting a form with incomplete mandatory fields.
- Recommended regression testing across other Observation forms to ensure the same behavior throughout the module.

Hive card details: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=CX7MipL9Nw3Frjexj