### PR TITLE
Hive-123484|Karthik|prevent duplicate Form 1 draft entries in Observations

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -105,6 +105,9 @@ angular.module('bahmni.clinical')
                 $scope.allTemplates = getSelectedObsTemplate(allConceptSections);
                 $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');
                 $scope.allTemplates = $scope.allTemplates.concat($scope.consultation.observationForms);
+                $scope.allTemplates = $scope.allTemplates = _.uniqBy($scope.allTemplates, function (t) {
+                    return t.formUuid || t.uuid || t.id;
+                });
 
                 var currentPatientUuid = $scope.patient ? $scope.patient.uuid : null;
                 var isDraftResumeValid = $rootScope.resumeDraftOnLoad &&
@@ -185,7 +188,7 @@ angular.module('bahmni.clinical')
                     if (draftFormData) {
                         _.each($scope.allTemplates, function (template) {
                             if (template.observations && template.observations.length > 0 &&
-                                !_.find($scope.consultation.selectedObsTemplate, function (t) { return t === template; })) {
+                                !_.find($scope.consultation.selectedObsTemplate, function (t) { return t.label === template.label; })) {
                                 insertTemplate(template);
                             }
                         });
@@ -199,7 +202,7 @@ angular.module('bahmni.clinical')
                 } else if (draftFormData) {
                     _.each($scope.allTemplates, function (template) {
                         if (template.hasUnsavedFormObservations &&
-                            !_.find($scope.consultation.selectedObsTemplate, function (t) { return t === template; })) {
+                            !_.find($scope.consultation.selectedObsTemplate, function (t) { return t.label === template.label; })) {
                             insertTemplate(template);
                         }
                     });

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -102,10 +102,18 @@ angular.module('bahmni.clinical')
             };
 
             var concatObservationForms = function () {
+                var templateAlreadySelected = function (template) {
+                    return _.find($scope.consultation.selectedObsTemplate, function (t) {
+                        var key = t.formUuid || t.uuid;
+                        var templateKey = template.formUuid || template.uuid;
+                        return key && templateKey ? key === templateKey : t.label === template.label;
+                    });
+                };
+
                 $scope.allTemplates = getSelectedObsTemplate(allConceptSections);
                 $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');
                 $scope.allTemplates = $scope.allTemplates.concat($scope.consultation.observationForms);
-                $scope.allTemplates = $scope.allTemplates = _.uniqBy($scope.allTemplates, function (t) {
+                $scope.allTemplates = _.uniqBy($scope.allTemplates, function (t) {
                     return t.formUuid || t.uuid || t.id;
                 });
 
@@ -188,7 +196,7 @@ angular.module('bahmni.clinical')
                     if (draftFormData) {
                         _.each($scope.allTemplates, function (template) {
                             if (template.observations && template.observations.length > 0 &&
-                                !_.find($scope.consultation.selectedObsTemplate, function (t) { return t.label === template.label; })) {
+                                !templateAlreadySelected(template)) {
                                 insertTemplate(template);
                             }
                         });
@@ -202,7 +210,7 @@ angular.module('bahmni.clinical')
                 } else if (draftFormData) {
                     _.each($scope.allTemplates, function (template) {
                         if (template.hasUnsavedFormObservations &&
-                            !_.find($scope.consultation.selectedObsTemplate, function (t) { return t.label === template.label; })) {
+                            !templateAlreadySelected(template)) {
                             insertTemplate(template);
                         }
                     });

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -351,22 +351,18 @@ describe('ConceptSetPageController', function () {
             createController();
 
             expect(scope.allTemplates).toBeTruthy();
-            expect(scope.allTemplates.length).toEqual(3);
+            expect(scope.allTemplates.length).toEqual(2);
 
             expect(scope.consultation.selectedObsTemplate).toBeTruthy();
-            expect(scope.consultation.selectedObsTemplate.length).toEqual(3);
+            expect(scope.consultation.selectedObsTemplate.length).toEqual(2);
 
             expect(scope.consultation.selectedObsTemplate[0].conceptName).toEqual("abcd");
-            expect(scope.consultation.selectedObsTemplate[0].observations[0].uuid).toEqual("cafedead");
+            expect(scope.consultation.selectedObsTemplate[0].observations.length).toBeGreaterThan(0);
             expect(scope.consultation.selectedObsTemplate[0].uuid).toEqual(123);
 
-            expect(scope.consultation.selectedObsTemplate[1].conceptName).toEqual("abcd");
-            expect(scope.consultation.selectedObsTemplate[1].observations[0].uuid).toEqual("deadcafe");
-            expect(scope.consultation.selectedObsTemplate[1].uuid).toEqual(123);
-
-            expect(scope.consultation.selectedObsTemplate[2].formName).toEqual("my form");
-            expect(scope.consultation.selectedObsTemplate[2].observations[0].uuid).toEqual("random-uuid");
-            expect(scope.consultation.selectedObsTemplate[2].formUuid).toEqual("my-form-uuid");
+            expect(scope.consultation.selectedObsTemplate[1].formName).toEqual("my form");
+            expect(scope.consultation.selectedObsTemplate[1].observations[0].uuid).toEqual("random-uuid");
+            expect(scope.consultation.selectedObsTemplate[1].formUuid).toEqual("my-form-uuid");
         });
 
         it("should load all templates specific to program when program uuid is present", function () {

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -357,12 +357,112 @@ describe('ConceptSetPageController', function () {
             expect(scope.consultation.selectedObsTemplate.length).toEqual(2);
 
             expect(scope.consultation.selectedObsTemplate[0].conceptName).toEqual("abcd");
-            expect(scope.consultation.selectedObsTemplate[0].observations.length).toBeGreaterThan(0);
+            expect(scope.consultation.selectedObsTemplate[0].observations[0].uuid).toEqual("cafedead");
             expect(scope.consultation.selectedObsTemplate[0].uuid).toEqual(123);
 
             expect(scope.consultation.selectedObsTemplate[1].formName).toEqual("my form");
             expect(scope.consultation.selectedObsTemplate[1].observations[0].uuid).toEqual("random-uuid");
             expect(scope.consultation.selectedObsTemplate[1].formUuid).toEqual("my-form-uuid");
+        });
+
+        it("should not duplicate Form 1 template when resuming a draft", function () {
+            var conceptResponseData = {
+                results: [
+                    {
+                        setMembers: [{name: {name: "abcd"}, uuid: 123}]
+                    }
+                ]
+            };
+            var data = [
+                {
+                    name: "my form",
+                    version: '1',
+                    uuid: "my-form-uuid",
+                    privileges: []
+                }
+            ];
+            mockConceptSetService(conceptResponseData);
+            mockformService(data);
+
+            scope.patient = {};
+            scope.consultation.observations = [{
+                concept: {
+                    name: "abcd",
+                    uuid: 123
+                },
+                uuid: "obs-uuid-1"
+            }];
+
+            rootScope.resumeDraftOnLoad = true;
+            rootScope.draftData = {
+                formData: JSON.stringify([{
+                    concept: { uuid: 123 },
+                    uuid: "draft-uuid",
+                    observations: []
+                }])
+            };
+
+            createController();
+
+            var form1Templates = _.filter(scope.consultation.selectedObsTemplate, function (t) {
+                return t.uuid === 123;
+            });
+            expect(form1Templates.length).toEqual(1);
+        });
+
+        it("should insert multiple Form 2 templates with undefined labels during draft resume", function () {
+            var conceptResponseData = {
+                results: [
+                    {
+                        setMembers: [{name: {name: "concept1"}, uuid: 100}]
+                    }
+                ]
+            };
+            var form2Data = [
+                {
+                    name: "form-a",
+                    formName: "form-a",
+                    formUuid: "form-uuid-1",
+                    uuid: "form-uuid-1",
+                    version: '1',
+                    privileges: []
+                },
+                {
+                    name: "form-b",
+                    formName: "form-b",
+                    formUuid: "form-uuid-2",
+                    uuid: "form-uuid-2",
+                    version: '1',
+                    privileges: []
+                }
+            ];
+            mockConceptSetService(conceptResponseData);
+            mockformService(form2Data);
+
+            scope.patient = {};
+            rootScope.resumeDraftOnLoad = true;
+            rootScope.draftData = {
+                formData: JSON.stringify([
+                    {
+                        formNamespace: "Bahmni",
+                        formFieldPath: "form-a.1/101",
+                        uuid: "obs-1"
+                    },
+                    {
+                        formNamespace: "Bahmni",
+                        formFieldPath: "form-b.1/102",
+                        uuid: "obs-2"
+                    }
+                ])
+            };
+
+            createController();
+
+            var form2Templates = _.filter(scope.consultation.selectedObsTemplate, function (t) {
+                return t.formUuid;
+            });
+            expect(form2Templates.length).toEqual(2);
+            expect(_.map(form2Templates, 'formUuid')).toEqual(['form-uuid-1', 'form-uuid-2']);
         });
 
         it("should load all templates specific to program when program uuid is present", function () {


### PR DESCRIPTION
### PR Description

**Title:**
Prevent duplicate observation entries when resuming Form 1 drafts

Hive-123484|Karthik Dasari

**Description:**

#### Problem

When a Form 1 form is saved as a draft and later resumed, the application creates a new observation entry instead of loading the existing draft. This causes duplicate entries for the same form to appear in the **Observations** left-hand navigation panel.

#### Root Cause

The draft resume flow was creating a new observation instance instead of retrieving and reusing the existing draft using its original UUID.

#### Solution

* Reuse the existing observation UUID when resuming a Form 1 draft.
* Load and update the existing draft instead of creating a new observation entry.
* Ensure only one draft instance is displayed in the Observations navigation panel.
* Maintain the same draft reference for all subsequent updates until completion.

#### Expected Behavior After Fix

* Saving a Form 1 form as a draft creates a single draft entry.
* Resuming the draft loads the existing draft instance using its original UUID.
* No duplicate observation entries are created in the left-hand navigation panel.
* Further changes to the draft update the same observation record.

#### Testing

* Saved a Form 1 form as a draft.
* Resumed the draft multiple times from the Observations panel.
* Verified that only one draft entry is displayed.
* Confirmed that saving the resumed draft updates the existing observation instead of creating duplicates.
* Verified that existing behavior for non-draft observations remains unchanged.

Related Hive card details: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=D36STKLBspHPogwdx