### PR TITLE
Hive-123346|Karthik|preserve unsaved observation forms when user navigates to other modules

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -6,7 +6,7 @@ angular.module('bahmni.clinical')
         'contextChangeHandler', '$q', '$translate', 'formService', '$timeout', '$filter', 'appService', 'formDraftService', 'formDirtyStateService', 'autoSaveService',
         function ($scope, $rootScope, $stateParams, conceptSetService,
                   clinicalAppConfigService, messagingService, configurations, $state, spinner,
-              contextChangeHandler, $q, $translate, formService, $timeout, $filter, appService, formDraftService, formDirtyStateService, autoSaveService) {
+            contextChangeHandler, $q, $translate, formService, $timeout, $filter, appService, formDraftService, formDirtyStateService, autoSaveService) {
             $scope.consultation.selectedObsTemplate = $scope.consultation.selectedObsTemplate || [];
             $scope.allTemplates = $scope.allTemplates || [];
             $scope.scrollingEnabled = false;
@@ -122,15 +122,8 @@ angular.module('bahmni.clinical')
                     $rootScope.draftData &&
                     (!$rootScope.resumeDraftPatientUuid || $rootScope.resumeDraftPatientUuid === currentPatientUuid);
 
-                if (!isDraftResumeValid) {
-                    var hasStaleUnsavedObs = _.some($scope.consultation.selectedObsTemplate, function (t) {
-                        return t.hasUnsavedFormObservations;
-                    }) || _.some($scope.consultation.observationForms, function (f) {
-                        return f.hasUnsavedFormObservations;
-                    });
-                    if (hasStaleUnsavedObs) {
-                        clearStaleObsFromTemplates();
-                    }
+                if (!isDraftResumeValid && $scope.visitHistory && !$scope.visitHistory.activeVisit) {
+                    clearStaleObsFromTemplates();
                 }
 
                 var draftFormData = isDraftResumeValid && $rootScope.draftData.formData ? $rootScope.draftData.formData : null;
@@ -441,7 +434,7 @@ angular.module('bahmni.clinical')
                     }
                     if ($scope.isFormEditableByTheUser(observationForm)) {
                         var newForm = new Bahmni.ObservationForm(formUuid, $rootScope.currentUser,
-                                                                   formName, formVersion, observations, label, extension);
+                            formName, formVersion, observations, label, extension);
                         newForm.privileges = privileges;
                         forms.push(newForm);
                     }

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -122,6 +122,9 @@ angular.module('bahmni.clinical')
                     $rootScope.draftData &&
                     (!$rootScope.resumeDraftPatientUuid || $rootScope.resumeDraftPatientUuid === currentPatientUuid);
 
+                // Guard: only clear stale obs when there is no active visit.
+                // Bug fix: previously this ran on every concatObservationForms call when isDraftResumeValid
+                // was false (including during active-visit cross-module navigation), wiping unsaved forms.
                 if (!isDraftResumeValid && $scope.visitHistory && !$scope.visitHistory.activeVisit) {
                     clearStaleObsFromTemplates();
                 }

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -3005,8 +3005,8 @@ describe('ConceptSetPageController', function () {
             createController();
 
             var hasAnyFormUnsaved = _.some(scope.consultation.observationForms, function (f) { return f.hasUnsavedFormObservations; });
-            expect(hasAnyFormUnsaved).toBe(false);
-            expect(scope.consultation.observationForms[0].observations.length).toBe(0);
+            expect(hasAnyFormUnsaved).toBe(true);
+            expect(scope.consultation.observationForms[0].observations.length).toBe(1);
         });
     });
 

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -2987,12 +2987,13 @@ describe('ConceptSetPageController', function () {
             expect(rootScope.draftData).toBeNull();
         });
 
-        it('should clear stale hasUnsavedFormObservations in concatObservationForms when isDraftResumeValid is false and activeVisit is present', function () {
+        it('should preserve unsaved form observations in concatObservationForms when isDraftResumeValid is false but activeVisit is present', function () {
             rootScope.resumeDraftOnLoad = false;
             rootScope.draftData = null;
             scope.visitHistory = {activeVisit: {uuid: 'active-visit-uuid'}};
             // Pre-populate selectedObsTemplate so initializeDefaultTemplates is skipped,
-            // and set a stale unsaved form obs on observationForms to exercise the stale-obs guard
+            // and set a stale unsaved form obs on observationForms to verify
+            // that the stale-obs guard does NOT fire when an active visit is present.
             scope.consultation.selectedObsTemplate = [{uuid: 'tmpl-1', label: 'Template 1'}];
             scope.consultation.observationForms = [{
                 formName: 'Form1',


### PR DESCRIPTION
# Preserve unsaved observation forms during module navigation

Hive-123346 | Karthik Dasari

Problem

When a user adds a new observation form containing mandatory fields and partially fills it, the form is removed from the side panel when navigating away from the Observation forms page. The partially entered data is lost, requiring the user to add the form again and re-enter the information.

This issue occurs during cross-module navigation and is not limited to save actions triggered from other modules.

Root Cause

The application does not preserve the state of newly added, unsaved observation forms when the user navigates between modules. The temporary observation data is cleared during navigation, causing the form entry and partially completed values to be lost.

**Expected Behavior After Fix**: 

Newly added observation forms remain visible in the side panel after navigating to other modules.
All previously entered values are retained.
Users can return to the observation form, complete mandatory fields, and save successfully.
Unsaved form state is preserved until an explicit user action removes it.

**Testing**:

Added a new observation form with mandatory fields.
Entered partial data while leaving required fields incomplete.
Navigated to different modules without saving the observation form.
Verified that the form remained available in the side panel.
Confirmed that previously entered data was preserved after returning to the Observation forms page.
Tested save attempts from other modules and verified that validation failures no longer remove the form.

Related Hive card details: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=wyQ7F3DjHP2EqCSCL