### PR TITLE
Hive -123340 | Nandini | Fix VDP instruction leak and conditional pipe separator in medications display

### DIFF
--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -101,7 +101,7 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
     this.route = this.route || undefined;
     this.durationUnit = this.durationUnit || inputOptionsConfig.defaultDurationUnit;
     this.simpleDrugForm = this.simpleDrugForm || inputOptionsConfig.simpleDrugForm || false;
-    this.instructions = this.instructions || inputOptionsConfig.defaultInstructions;
+    this.instructions = this.instructions || undefined;
     this.autoExpireDate = this.autoExpireDate || undefined;
     this.frequencyType = this.frequencyType || Bahmni.Clinical.Constants.dosingTypes.uniform;
     this.isLoadingDose = this.isLoadingDose || false;
@@ -800,6 +800,7 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
         viewModel.isNonCodedDrug = !!drugOrderResponse.drugNonCoded;
         viewModel.drugNameDisplay = viewModel.drugNonCoded || constructDrugNameDisplayWithConcept(viewModel.drug, viewModel.concept) || viewModel.drugName;
         viewModel.asNeeded = false;
+        viewModel.instructions = undefined;
         viewModel.dosage = '';
         viewModel.orderNumber = drugOrderResponse.orderNumber && parseInt(drugOrderResponse.orderNumber.replace('ORD-', ''));
         if (drugOrderResponse.orderGroup) {

--- a/ui/app/clinical/consultation/views/newDrugOrders.html
+++ b/ui/app/clinical/consultation/views/newDrugOrders.html
@@ -74,7 +74,7 @@
                 </div>
                 <div ng-if="newTreatment.rate"> | {{newTreatment.rate}} ml/hr</div>
                 <div ng-if="newTreatment.additives"> | {{newTreatment.additives}}</div>
-                <div ng-if="newTreatment.getQuantityWithUnit()"> | {{newTreatment.getQuantityWithUnit()}}</div>
+                <div ng-if="newTreatment.getQuantityWithUnit()"><span ng-if="newTreatment.route || newTreatment.instructions"> | </span>{{newTreatment.getQuantityWithUnit()}}</div>
                 <div ng-show="newTreatment.isDischargeMedication"> | {{ ::'DISCH_LABEL' | translate }}</div>
             </div>
             <cdss-alert-row alerts="newTreatment.alerts"></cdss-alert-row>
@@ -117,7 +117,7 @@
             <div class="dosage-details">
                 <div>
                     <span ng-if="treatment.route">{{treatment.route}}</span>
-                    <span ng-if="treatment.quantity"> | {{treatment.quantity}} {{treatment.quantityUnit}}</span>
+                    <span ng-if="treatment.quantity"><span ng-if="treatment.route"> | </span>{{treatment.quantity}} {{treatment.quantityUnit}}</span>
                 </div>
             </div>
             <mfe-next-ui-variable-dose-protocol-table host-data="treatment">

--- a/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
@@ -87,7 +87,7 @@
                                     <div ng-if="drugOrder.additionalInstructions"> | {{drugOrder.additionalInstructions}}</div>
                                     <div ng-if="drugOrder.rate"> | {{drugOrder.rate}} ml/hr</div>
                                     <div ng-if="drugOrder.additives"> | {{drugOrder.additives}}</div>
-                                    <div ng-if="drugOrder.getQuantityWithUnit()"> | {{drugOrder.getQuantityWithUnit()}}</div>
+                                    <div ng-if="drugOrder.getQuantityWithUnit()"><span ng-if="drugOrder.route || drugOrder.instructions"> | </span>{{drugOrder.getQuantityWithUnit()}}</div>
                                     <div class="footer-note">
                                         <span class="time-stamp">
                                             <span class="time">{{drugOrder.dateActivated | bahmniDateTime}}</span>

--- a/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
+++ b/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
@@ -1053,6 +1053,68 @@ describe("drugOrderViewModel", function () {
         });
     });
 
+    describe("createFromContract - VDP orders should not have parent-level instructions", function () {
+        var fhirDosingInstructionType = 'org.openmrs.module.bahmniemrapi.drugorder.dosinginstructions.FhirDosingInstructions';
+
+        var buildVdpContract = function (overrides) {
+            var dosages = [
+                { sequence: 1, text: 'Stage 1', timing: { code: { text: 'Once a day' }, repeat: { duration: 3, durationUnit: 'd' } }, doseAndRate: [{ doseQuantity: { value: 5, unit: 'mg' } }], extension: [{ url: 'isLoadingDose', valueBoolean: false }], additionalInstruction: [], patientInstruction: '' }
+            ];
+            return Object.assign({
+                uuid: 'vdp-instr-uuid',
+                action: 'NEW',
+                careSetting: 'Inpatient',
+                dosingInstructionType: fhirDosingInstructionType,
+                effectiveStartDate: DateUtil.parse('2026-01-01').getTime(),
+                duration: 3,
+                durationUnits: 'Days',
+                dosingInstructions: {
+                    quantity: 10,
+                    quantityUnits: 'Tablet(s)',
+                    administrationInstructions: JSON.stringify(dosages)
+                },
+                drug: { name: 'Prednisolone', uuid: 'drug-uuid' },
+                provider: { name: 'Dr. Test' }
+            }, overrides || {});
+        };
+
+        it("should not have parent-level instructions for VDP order", function () {
+            var viewModel = Bahmni.Clinical.DrugOrderViewModel.createFromContract(buildVdpContract());
+            expect(viewModel.instructions).toBeUndefined();
+        });
+
+        it("should not have parent-level instructions even when route is present", function () {
+            var viewModel = Bahmni.Clinical.DrugOrderViewModel.createFromContract(buildVdpContract({
+                dosingInstructions: {
+                    route: 'Oral',
+                    quantity: 10,
+                    quantityUnits: 'Tablet(s)',
+                    administrationInstructions: JSON.stringify([
+                        { sequence: 1, text: 'Stage 1', timing: { code: { text: 'Once a day' }, repeat: { duration: 3, durationUnit: 'd' } }, doseAndRate: [{ doseQuantity: { value: 5, unit: 'mg' } }], extension: [{ url: 'isLoadingDose', valueBoolean: false }], additionalInstruction: [], patientInstruction: '' }
+                    ])
+                }
+            }));
+            expect(viewModel.instructions).toBeUndefined();
+            expect(viewModel.route).toBe('Oral');
+        });
+
+        it("should preserve stage-level instructions in stages array", function () {
+            var dosages = [
+                { sequence: 1, text: 'Stage 1', timing: { code: { text: 'Once a day' }, repeat: { duration: 3, durationUnit: 'd' } }, doseAndRate: [{ doseQuantity: { value: 5, unit: 'mg' } }], extension: [{ url: 'isLoadingDose', valueBoolean: false }], additionalInstruction: [{ text: 'Take after food' }], patientInstruction: '' }
+            ];
+            var viewModel = Bahmni.Clinical.DrugOrderViewModel.createFromContract(buildVdpContract({
+                dosingInstructions: {
+                    quantity: 10,
+                    quantityUnits: 'Tablet(s)',
+                    administrationInstructions: JSON.stringify(dosages)
+                }
+            }));
+            expect(viewModel.stages).toBeDefined();
+            expect(viewModel.stages.length).toBe(1);
+            expect(viewModel.stages[0].instructions).toBe('Take after food');
+        });
+    });
+
     describe("createFromContract - FHIR non-coded drug read-back", function () {
         var fhirDosingInstructionType = 'org.openmrs.module.bahmniemrapi.drugorder.dosinginstructions.FhirDosingInstructions';
 


### PR DESCRIPTION
### Changes
- Clear parent-level `instructions` in FHIR branch of `createFromContract` to prevent "As directed" leaking into saved VDP orders
- Changed constructor default from `inputOptionsConfig.defaultInstructions` to `undefined` so new normal orders still get the default via UX
- Conditional `|` separator before quantity when route/instructions are empty in `drugOrderHistory.html`, `newDrugOrders.html` (normal + VDP)
- Added unit tests verifying VDP orders have undefined parent-level instructions, route is unaffected, and stage-level instructions preserved