### PR TITLE
Pooja | Hive-123571 | Update logic for OT list view to work even when there is no custom list view requirement

### DIFF
--- a/ui/app/ot/controller/listViewController.js
+++ b/ui/app/ot/controller/listViewController.js
@@ -54,8 +54,6 @@ angular.module('bahmni.ot')
                 var appDescriptor = appService.getAppDescriptor();
                 var customTemplateUrl = appDescriptor.getConfigValue("listViewTemplateUrl");
                 var customTableInfo = appDescriptor.getConfigValue("listViewColumns") || [];
-                // Custom columns are only used when BOTH template URL and columns are configured.
-                // The custom template is responsible for rendering tableInfo in a non-standard way.
                 if (customTemplateUrl && customTableInfo.length > 0) {
                     return customTableInfo;
                 }

--- a/ui/app/ot/controller/listViewController.js
+++ b/ui/app/ot/controller/listViewController.js
@@ -44,34 +44,58 @@ angular.module('bahmni.ot')
 
             $scope.tableInfo = getTableInfo();
 
-            function getTableInfo () {
-                var customTableInfo = appService.getAppDescriptor().getConfigValue("listViewColumns") || [];
-                if (customTableInfo.length > 0) {
-                    return customTableInfo;
-                } else {
-                    var listViewAttributes = [
-                        {heading: 'Status', sortInfo: 'status'},
-                        {heading: 'Day', sortInfo: 'derivedAttributes.expectedStartDate'},
-                        {heading: 'Date', sortInfo: 'derivedAttributes.expectedStartDate'},
-                        {heading: 'Identifier', sortInfo: 'derivedAttributes.patientIdentifier'},
-                        {heading: 'Patient Name', sortInfo: 'derivedAttributes.patientName'},
-                        {heading: 'Patient Age', sortInfo: 'derivedAttributes.patientAge'},
-                        {heading: 'Start Time', sortInfo: 'derivedAttributes.expectedStartTime'},
-                        {heading: 'Est Time', sortInfo: 'derivedAttributes.duration'},
-                        {heading: 'Actual Time', sortInfo: 'actualStartDatetime'},
-                        {heading: 'OT#', sortInfo: 'surgicalBlock.location.name'},
-                        {heading: 'Surgeon', sortInfo: 'surgicalBlock.provider.person.display'}];
+            function getObservationColumnsTableInfo () {
+                return $scope.filteredObservationColumns.map(function (column) {
+                    return { heading: column.heading, sortInfo: null };
+                });
+            }
 
-                    var attributesRelatedToBed = [{heading: 'Status Change Notes', sortInfo: 'notes'},
-                        {heading: 'Bed Location', sortInfo: 'bedLocation'},
-                        {heading: 'Bed ID', sortInfo: 'bedNumber'}];
-                    if ($rootScope.showPrimaryDiagnosisForOT != null && $rootScope.showPrimaryDiagnosisForOT != "") {
-                        var primaryDiagnosisInfo = [{heading: 'Primary Diagnoses', sortInfo: 'patientObservations'}];
-                        return listViewAttributes.concat(getSurgicalAttributesTableInfo(), attributesRelatedToBed, primaryDiagnosisInfo);
-                    } else {
-                        return listViewAttributes.concat(getSurgicalAttributesTableInfo(), attributesRelatedToBed);
-                    }
+            function getTableInfo () {
+                var customTemplateUrl = appService.getAppDescriptor().getConfigValue("listViewTemplateUrl");
+                var customTableInfo = appService.getAppDescriptor().getConfigValue("listViewColumns") || [];
+                if (customTemplateUrl && customTableInfo.length > 0) {
+                    return customTableInfo;
                 }
+
+                var listViewAttributes = [
+                    {heading: 'Identifier', sortInfo: 'derivedAttributes.patientIdentifier'},
+                    {heading: 'Patient Name', sortInfo: 'derivedAttributes.patientName'},
+                    {heading: 'Status', sortInfo: 'status'}
+                ];
+
+                if ($scope.conceptFormatAttributeName) {
+                    listViewAttributes.push({
+                        heading: $scope.conceptFormatAttributeName,
+                        sortInfo: 'surgicalAppointmentAttributes.' + $scope.conceptFormatAttributeName + '.value'
+                    });
+                }
+
+                listViewAttributes = listViewAttributes.concat(getObservationColumnsTableInfo());
+
+                listViewAttributes = listViewAttributes.concat([
+                    {heading: 'Day', sortInfo: 'derivedAttributes.expectedStartDate'},
+                    {heading: 'Date', sortInfo: 'derivedAttributes.expectedStartDate'},
+                    {heading: 'Patient Age', sortInfo: 'derivedAttributes.patientAge'},
+                    {heading: 'Start Time', sortInfo: 'derivedAttributes.expectedStartTime'},
+                    {heading: 'Est Time', sortInfo: 'derivedAttributes.duration'},
+                    {heading: 'Actual Time', sortInfo: 'actualStartDatetime'},
+                    {heading: 'OT#', sortInfo: 'surgicalBlock.location.name'},
+                    {heading: 'Surgeon', sortInfo: 'surgicalBlock.provider.person.display'}
+                ]);
+
+                var attributesRelatedToBed = [
+                    {heading: 'Status Change Notes', sortInfo: 'notes'},
+                    {heading: 'Bed Location', sortInfo: 'bedLocation'},
+                    {heading: 'Bed ID', sortInfo: 'bedNumber'}
+                ];
+
+                if ($rootScope.showPrimaryDiagnosisForOT != null && $rootScope.showPrimaryDiagnosisForOT != "") {
+                    return listViewAttributes.concat(
+                        getSurgicalAttributesTableInfo(), attributesRelatedToBed,
+                        [{heading: 'Primary Diagnoses', sortInfo: 'patientObservations'}]
+                    );
+                }
+                return listViewAttributes.concat(getSurgicalAttributesTableInfo(), attributesRelatedToBed);
             }
 
             function getFilteredSurgicalAttributeTypes () {

--- a/ui/app/ot/controller/listViewController.js
+++ b/ui/app/ot/controller/listViewController.js
@@ -45,14 +45,17 @@ angular.module('bahmni.ot')
             $scope.tableInfo = getTableInfo();
 
             function getObservationColumnsTableInfo () {
-                return $scope.filteredObservationColumns.map(function (column) {
+                return ($scope.filteredObservationColumns || []).map(function (column) {
                     return { heading: column.heading, sortInfo: null };
                 });
             }
 
             function getTableInfo () {
-                var customTemplateUrl = appService.getAppDescriptor().getConfigValue("listViewTemplateUrl");
-                var customTableInfo = appService.getAppDescriptor().getConfigValue("listViewColumns") || [];
+                var appDescriptor = appService.getAppDescriptor();
+                var customTemplateUrl = appDescriptor.getConfigValue("listViewTemplateUrl");
+                var customTableInfo = appDescriptor.getConfigValue("listViewColumns") || [];
+                // Custom columns are only used when BOTH template URL and columns are configured.
+                // The custom template is responsible for rendering tableInfo in a non-standard way.
                 if (customTemplateUrl && customTableInfo.length > 0) {
                     return customTableInfo;
                 }
@@ -246,8 +249,8 @@ angular.module('bahmni.ot')
                 }
             });
 
-            $scope.$watch("filterParams", function (oldValue, newValue) {
-                if (oldValue !== newValue) {
+            $scope.$watch("filterParams", function (newValue, oldValue) {
+                if (newValue !== oldValue) {
                     filterSurgicalBlocksAndMapAppointmentsForDisplay($scope.surgicalBlocks);
                 }
             });

--- a/ui/app/ot/controller/newSurgicalAppointmentController.js
+++ b/ui/app/ot/controller/newSurgicalAppointmentController.js
@@ -18,7 +18,7 @@ angular.module('bahmni.ot')
                     $scope.conceptFormatAttributeName = otUtils.getConceptFormatAttributeName();
                     $scope.conceptFormatAttributeNames = otUtils.getConceptFormatAttributeNames();
                     var configuredRequired = appService.getAppDescriptor().getConfigValue("requiredSurgeryAttributes");
-                    $scope.requiredConceptAttributes = configuredRequired || [$scope.conceptFormatAttributeName];
+                    $scope.requiredConceptAttributes = configuredRequired || [];
                     var attributes = {};
                     var mapAttributes = new Bahmni.OT.SurgicalBlockMapper().mapAttributes(attributes, $scope.attributeTypes);
                     $scope.attributes = $scope.ngDialogData && $scope.ngDialogData.surgicalAppointmentAttributes || mapAttributes;

--- a/ui/test/unit/ot/controller/listViewController.spec.js
+++ b/ui/test/unit/ot/controller/listViewController.spec.js
@@ -907,5 +907,48 @@ describe('listViewController', function () {
         expect(scope.tableInfo.length).toBe(22);
         expect(scope.tableInfo[21].heading).toBe('Primary Diagnoses');
         expect(scope.tableInfo[21].sortInfo).toBe('patientObservations');
-        })
+        });
+
+    it("should set sortInfo to null for observation columns in tableInfo", function () {
+        appDescriptor.getConfigValue.and.callFake(function (configName) {
+            if (configName === 'listViewObservationColumns') {
+                return [{concept: "Haemoglobin", type: "date", label: "Hb Date"}];
+            }
+            return null;
+        });
+        createController();
+        var obsColumn = scope.tableInfo.find(function (col) { return col.heading === "Hb Date"; });
+        expect(obsColumn).toBeDefined();
+        expect(obsColumn.sortInfo).toBeNull();
+    });
+
+    it("should add observation column headings to defaultAttributeTranslations", function () {
+        appDescriptor.getConfigValue.and.callFake(function (configName) {
+            if (configName === 'listViewObservationColumns') {
+                return [
+                    {concept: "Haemoglobin", label: "OT_HB_LABEL"},
+                    {concept: "Pre Anaesthesia Assessed for Surgery?", type: "date", label: "OT_ANAESTHESIA_REVIEW_DATE"}
+                ];
+            }
+            return null;
+        });
+        createController();
+        expect(scope.defaultAttributeTranslations.get("OT_HB_LABEL")).toBe("OT_HB_LABEL");
+        expect(scope.defaultAttributeTranslations.get("OT_ANAESTHESIA_REVIEW_DATE")).toBe("OT_ANAESTHESIA_REVIEW_DATE");
+    });
+
+    it("should include both conceptFormatAttribute and observation columns in correct order in tableInfo", function () {
+        otUtils.getConceptFormatAttributeName.and.returnValue('Blood Transfusion Requested for Surgery?');
+        appDescriptor.getConfigValue.and.callFake(function (configName) {
+            if (configName === 'listViewObservationColumns') {
+                return [{concept: "Haemoglobin", label: "Hb"}];
+            }
+            return null;
+        });
+        createController();
+        expect(scope.tableInfo[3].heading).toBe('Blood Transfusion Requested for Surgery?');
+        expect(scope.tableInfo[4].heading).toBe('Hb');
+        expect(scope.tableInfo[4].sortInfo).toBeNull();
+        expect(scope.tableInfo[5].heading).toBe('Day');
+    });
 });

--- a/ui/test/unit/ot/controller/listViewController.spec.js
+++ b/ui/test/unit/ot/controller/listViewController.spec.js
@@ -723,6 +723,7 @@ describe('listViewController', function () {
     });
 
     it("should have assessment and other fields in table info when configured", function () {
+        otUtils.getConceptFormatAttributeName.and.returnValue(undefined);
         appDescriptor.getConfigValue.and.callFake(function (configName) {
             if (configName === 'listViewObservationColumns') {
                 return [
@@ -742,19 +743,20 @@ describe('listViewController', function () {
         rootScope.attributeTypes = defaultAttributeTypes;
         rootScope.showPrimaryDiagnosisForOT = true;
         createController();
-        expect(scope.tableInfo.length).toBe(22);
+        expect(scope.tableInfo.length).toBe(27);
         expect(scope.filteredObservationColumns.length).toBe(4);
         expect(scope.filteredObservationColumns[0].heading).toBe("OT_ANAESTHESIA_REVIEW_DATE");
         expect(scope.filteredObservationColumns[1].heading).toBe("OT_ANAESTHESIA_REVIEW");
-        expect(scope.tableInfo[19].heading).toBe("Bed Location");
-        expect(scope.tableInfo[19].sortInfo).toBe("bedLocation");
-        expect(scope.tableInfo[20].heading).toBe("Bed ID");
-        expect(scope.tableInfo[20].sortInfo).toBe("bedNumber");
-        expect(scope.tableInfo[21].heading).toBe("Primary Diagnoses");
-        expect(scope.tableInfo[21].sortInfo).toBe("patientObservations");
+        expect(scope.tableInfo[24].heading).toBe("Bed Location");
+        expect(scope.tableInfo[24].sortInfo).toBe("bedLocation");
+        expect(scope.tableInfo[25].heading).toBe("Bed ID");
+        expect(scope.tableInfo[25].sortInfo).toBe("bedNumber");
+        expect(scope.tableInfo[26].heading).toBe("Primary Diagnoses");
+        expect(scope.tableInfo[26].sortInfo).toBe("patientObservations");
     });
 
     it("should not include assessment columns when config is absent", function () {
+        otUtils.getConceptFormatAttributeName.and.returnValue(undefined);
         appDescriptor.getConfigValue.and.callFake(function (configName) {
             if (configName === 'listViewObservationColumns') {
                 return undefined;
@@ -775,10 +777,11 @@ describe('listViewController', function () {
         expect(headings).not.toContain("OT_ANAESTHESIA_REVIEW");
         expect(headings).not.toContain("OT_PAEDIATRIC_REVIEW_DATE");
         expect(headings).not.toContain("OT_PAEDIATRIC_REVIEW");
-        expect(scope.tableInfo.length).toBe(22);
+        expect(scope.tableInfo.length).toBe(23);
     });
 
     it("should not include assessment columns when config is empty array", function () {
+        otUtils.getConceptFormatAttributeName.and.returnValue(undefined);
         appDescriptor.getConfigValue.and.callFake(function (configName) {
             if (configName === 'listViewObservationColumns') {
                 return [];
@@ -799,10 +802,11 @@ describe('listViewController', function () {
         expect(headings).not.toContain("OT_ANAESTHESIA_REVIEW");
         expect(headings).not.toContain("OT_PAEDIATRIC_REVIEW_DATE");
         expect(headings).not.toContain("OT_PAEDIATRIC_REVIEW");
-        expect(scope.tableInfo.length).toBe(22);
+        expect(scope.tableInfo.length).toBe(23);
     });
 
     it("should include only configured assessment columns in configured order", function () {
+        otUtils.getConceptFormatAttributeName.and.returnValue(undefined);
         appDescriptor.getConfigValue.and.callFake(function (configName) {
             if (configName === 'listViewObservationColumns') {
                 return [
@@ -821,7 +825,7 @@ describe('listViewController', function () {
         rootScope.showPrimaryDiagnosisForOT = true;
         createController();
 
-        expect(scope.tableInfo.length).toBe(22);
+        expect(scope.tableInfo.length).toBe(25);
         expect(scope.filteredObservationColumns.length).toBe(2);
         expect(scope.filteredObservationColumns[0].heading).toBe("OT_PAEDIATRIC_REVIEW");
         expect(scope.filteredObservationColumns[1].heading).toBe("OT_ANAESTHESIA_REVIEW_DATE");
@@ -858,6 +862,7 @@ describe('listViewController', function () {
     });
 
     it('should have all the surgical attributes in table info', function () {
+        otUtils.getConceptFormatAttributeName.and.returnValue(undefined);
         appDescriptor.getConfigValue.and.callFake(function (configName) {
             if (configName === 'listViewObservationColumns') {
                 return [
@@ -877,21 +882,21 @@ describe('listViewController', function () {
         rootScope.attributeTypes = defaultAttributeTypes;
         rootScope.showPrimaryDiagnosisForOT = true;
         createController();
-        expect(scope.tableInfo.length).toBe(22);
-        expect(scope.tableInfo[11].heading).toBe('procedure');
-        expect(scope.tableInfo[11].sortInfo).toBe('surgicalAppointmentAttributes.procedure.value');
-        expect(scope.tableInfo[12].heading).toBe('otherSurgeon');
-        expect(scope.tableInfo[12].sortInfo).toBe('surgicalAppointmentAttributes.otherSurgeon.value.person.display');
-        expect(scope.tableInfo[13].heading).toBe('surgicalAssistant');
-        expect(scope.tableInfo[13].sortInfo).toBe('surgicalAppointmentAttributes.surgicalAssistant.value');
-        expect(scope.tableInfo[14].heading).toBe('anaesthetist');
-        expect(scope.tableInfo[14].sortInfo).toBe('surgicalAppointmentAttributes.anaesthetist.value');
-        expect(scope.tableInfo[15].heading).toBe('scrubNurse');
-        expect(scope.tableInfo[15].sortInfo).toBe('surgicalAppointmentAttributes.scrubNurse.value');
-        expect(scope.tableInfo[16].heading).toBe('circulatingNurse');
-        expect(scope.tableInfo[16].sortInfo).toBe('surgicalAppointmentAttributes.circulatingNurse.value');
-        expect(scope.tableInfo[17].heading).toBe('notes');
-        expect(scope.tableInfo[17].sortInfo).toBe('surgicalAppointmentAttributes.notes.value');
+        expect(scope.tableInfo.length).toBe(27);
+        expect(scope.tableInfo[15].heading).toBe('procedure');
+        expect(scope.tableInfo[15].sortInfo).toBe('surgicalAppointmentAttributes.procedure.value');
+        expect(scope.tableInfo[16].heading).toBe('otherSurgeon');
+        expect(scope.tableInfo[16].sortInfo).toBe('surgicalAppointmentAttributes.otherSurgeon.value.person.display');
+        expect(scope.tableInfo[17].heading).toBe('surgicalAssistant');
+        expect(scope.tableInfo[17].sortInfo).toBe('surgicalAppointmentAttributes.surgicalAssistant.value');
+        expect(scope.tableInfo[18].heading).toBe('anaesthetist');
+        expect(scope.tableInfo[18].sortInfo).toBe('surgicalAppointmentAttributes.anaesthetist.value');
+        expect(scope.tableInfo[19].heading).toBe('scrubNurse');
+        expect(scope.tableInfo[19].sortInfo).toBe('surgicalAppointmentAttributes.scrubNurse.value');
+        expect(scope.tableInfo[20].heading).toBe('circulatingNurse');
+        expect(scope.tableInfo[20].sortInfo).toBe('surgicalAppointmentAttributes.circulatingNurse.value');
+        expect(scope.tableInfo[21].heading).toBe('notes');
+        expect(scope.tableInfo[21].sortInfo).toBe('surgicalAppointmentAttributes.notes.value');
     })
 
     it('should have primaryDiagnosisInfo attributes in table info', function () {
@@ -904,9 +909,9 @@ describe('listViewController', function () {
         rootScope.attributeTypes = defaultAttributeTypes;
         rootScope.showPrimaryDiagnosisForOT = true;
         createController();
-        expect(scope.tableInfo.length).toBe(22);
-        expect(scope.tableInfo[21].heading).toBe('Primary Diagnoses');
-        expect(scope.tableInfo[21].sortInfo).toBe('patientObservations');
+        expect(scope.tableInfo.length).toBe(23);
+        expect(scope.tableInfo[22].heading).toBe('Primary Diagnoses');
+        expect(scope.tableInfo[22].sortInfo).toBe('patientObservations');
         });
 
     it("should set sortInfo to null for observation columns in tableInfo", function () {
@@ -950,5 +955,69 @@ describe('listViewController', function () {
         expect(scope.tableInfo[4].heading).toBe('Hb');
         expect(scope.tableInfo[4].sortInfo).toBeNull();
         expect(scope.tableInfo[5].heading).toBe('Day');
+    });
+
+    it("should generate default table structure with observation columns when no custom template or listViewColumns configured", function () {
+        otUtils.getConceptFormatAttributeName.and.returnValue(undefined);
+        // Simulate real-world scenario: only listViewObservationColumns configured, no custom template or listViewColumns
+        appDescriptor.getConfigValue.and.callFake(function (configName) {
+            if (configName === 'listViewObservationColumns') {
+                return [
+                    {concept: "Haemoglobin", type: "date", label: "HB_DATE"},
+                    {concept: "Haemoglobin", label: "HB_VALUE"}
+                ];
+            }
+            if (configName === 'listViewTemplateUrl') {
+                return null; // No custom template
+            }
+            if (configName === 'listViewColumns') {
+                return null; // No custom columns config
+            }
+            return null;
+        });
+        scope.filterParams = {
+            providers: [],
+            locations: {"OT 1": true},
+            statusList: []
+        };
+        rootScope.attributeTypes = defaultAttributeTypes;
+        rootScope.showPrimaryDiagnosisForOT = true;
+        createController();
+
+        // Verify default structure is built (not custom template structure)
+        expect(scope.tableInfo).toBeDefined();
+        expect(scope.tableInfo.length).toBeGreaterThan(0);
+
+        // Verify it includes base columns (Identifier, Patient Name, Status)
+        var headings = scope.tableInfo.map(function(info) { return info.heading; });
+        expect(headings).toContain('Identifier');
+        expect(headings).toContain('Patient Name');
+        expect(headings).toContain('Status');
+
+        // Verify it includes observation columns
+        expect(headings).toContain('HB_DATE');
+        expect(headings).toContain('HB_VALUE');
+
+        // Verify it includes standard surgical columns
+        expect(headings).toContain('Day');
+        expect(headings).toContain('Date');
+        expect(headings).toContain('Patient Age');
+        expect(headings).toContain('OT#');
+        expect(headings).toContain('Surgeon');
+
+        // Verify observation columns have null sortInfo (not sortable)
+        var hbDateCol = scope.tableInfo.find(function(col) { return col.heading === 'HB_DATE'; });
+        var hbValueCol = scope.tableInfo.find(function(col) { return col.heading === 'HB_VALUE'; });
+        expect(hbDateCol.sortInfo).toBeNull();
+        expect(hbValueCol.sortInfo).toBeNull();
+
+        // Verify surgical attributes are included
+        var procedureCol = scope.tableInfo.find(function(col) { return col.heading === 'procedure'; });
+        expect(procedureCol).toBeDefined();
+        expect(procedureCol.sortInfo).toBe('surgicalAppointmentAttributes.procedure.value');
+
+        // Verify bed-related attributes are included
+        expect(headings).toContain('Bed Location');
+        expect(headings).toContain('Bed ID');
     });
 });

--- a/ui/test/unit/ot/controller/listViewController.spec.js
+++ b/ui/test/unit/ot/controller/listViewController.spec.js
@@ -641,7 +641,7 @@ describe('listViewController', function () {
         };
         var surgicalBlock = {uuid: "surgicalBlockUuid"};
         var appointment = surgicalAppointmentsForOT2Block[0];
-        appointment.surgicalBlock =  results[0];
+        appointment.surgicalBlock = results[0];
         createController();
         scope.selectSurgicalAppointment(event, appointment);
         expect(scope.$emit).toHaveBeenCalledWith("event:surgicalAppointmentSelect", appointment, appointment.surgicalBlock);
@@ -772,7 +772,7 @@ describe('listViewController', function () {
         rootScope.showPrimaryDiagnosisForOT = true;
         createController();
 
-        var headings = scope.tableInfo.map(function(info) { return info.heading; });
+        var headings = scope.tableInfo.map(function (info) { return info.heading; });
         expect(headings).not.toContain("OT_ANAESTHESIA_REVIEW_DATE");
         expect(headings).not.toContain("OT_ANAESTHESIA_REVIEW");
         expect(headings).not.toContain("OT_PAEDIATRIC_REVIEW_DATE");
@@ -797,7 +797,7 @@ describe('listViewController', function () {
         rootScope.showPrimaryDiagnosisForOT = true;
         createController();
 
-        var headings = scope.tableInfo.map(function(info) { return info.heading; });
+        var headings = scope.tableInfo.map(function (info) { return info.heading; });
         expect(headings).not.toContain("OT_ANAESTHESIA_REVIEW_DATE");
         expect(headings).not.toContain("OT_ANAESTHESIA_REVIEW");
         expect(headings).not.toContain("OT_PAEDIATRIC_REVIEW_DATE");
@@ -830,7 +830,7 @@ describe('listViewController', function () {
         expect(scope.filteredObservationColumns[0].heading).toBe("OT_PAEDIATRIC_REVIEW");
         expect(scope.filteredObservationColumns[1].heading).toBe("OT_ANAESTHESIA_REVIEW_DATE");
 
-        var headings = scope.tableInfo.map(function(info) { return info.heading; });
+        var headings = scope.tableInfo.map(function (info) { return info.heading; });
         expect(headings).not.toContain("OT_ANAESTHESIA_REVIEW");
         expect(headings).not.toContain("OT_PAEDIATRIC_REVIEW_DATE");
     });
@@ -959,7 +959,6 @@ describe('listViewController', function () {
 
     it("should generate default table structure with observation columns when no custom template or listViewColumns configured", function () {
         otUtils.getConceptFormatAttributeName.and.returnValue(undefined);
-        // Simulate real-world scenario: only listViewObservationColumns configured, no custom template or listViewColumns
         appDescriptor.getConfigValue.and.callFake(function (configName) {
             if (configName === 'listViewObservationColumns') {
                 return [
@@ -968,10 +967,10 @@ describe('listViewController', function () {
                 ];
             }
             if (configName === 'listViewTemplateUrl') {
-                return null; // No custom template
+                return null;
             }
             if (configName === 'listViewColumns') {
-                return null; // No custom columns config
+                return null;
             }
             return null;
         });
@@ -984,39 +983,32 @@ describe('listViewController', function () {
         rootScope.showPrimaryDiagnosisForOT = true;
         createController();
 
-        // Verify default structure is built (not custom template structure)
         expect(scope.tableInfo).toBeDefined();
         expect(scope.tableInfo.length).toBeGreaterThan(0);
 
-        // Verify it includes base columns (Identifier, Patient Name, Status)
-        var headings = scope.tableInfo.map(function(info) { return info.heading; });
+        var headings = scope.tableInfo.map(function (info) { return info.heading; });
         expect(headings).toContain('Identifier');
         expect(headings).toContain('Patient Name');
         expect(headings).toContain('Status');
 
-        // Verify it includes observation columns
         expect(headings).toContain('HB_DATE');
         expect(headings).toContain('HB_VALUE');
 
-        // Verify it includes standard surgical columns
         expect(headings).toContain('Day');
         expect(headings).toContain('Date');
         expect(headings).toContain('Patient Age');
         expect(headings).toContain('OT#');
         expect(headings).toContain('Surgeon');
 
-        // Verify observation columns have null sortInfo (not sortable)
-        var hbDateCol = scope.tableInfo.find(function(col) { return col.heading === 'HB_DATE'; });
-        var hbValueCol = scope.tableInfo.find(function(col) { return col.heading === 'HB_VALUE'; });
+        var hbDateCol = scope.tableInfo.find(function (col) { return col.heading === 'HB_DATE'; });
+        var hbValueCol = scope.tableInfo.find(function (col) { return col.heading === 'HB_VALUE'; });
         expect(hbDateCol.sortInfo).toBeNull();
         expect(hbValueCol.sortInfo).toBeNull();
 
-        // Verify surgical attributes are included
-        var procedureCol = scope.tableInfo.find(function(col) { return col.heading === 'procedure'; });
+        var procedureCol = scope.tableInfo.find(function (col) { return col.heading === 'procedure'; });
         expect(procedureCol).toBeDefined();
         expect(procedureCol.sortInfo).toBe('surgicalAppointmentAttributes.procedure.value');
 
-        // Verify bed-related attributes are included
         expect(headings).toContain('Bed Location');
         expect(headings).toContain('Bed ID');
     });


### PR DESCRIPTION
**Hive**: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?projectId=sfxBCpc3JKca3H2S8&actionViewId=aLgrTmXYc4HRqLbXw&tabId=thBjsTJW9AaHvQQBr&actionId=qFGbZhzk85wvrpdSu

**Key changes:**
1. **New Helper Function: getObservationColumnsTableInfo()**
  - Extracts observation column metadata into a reusable function that transforms filtered observation columns into table column objects with {heading, sortInfo: null } format.                                                                                                                                                                                           
  - Includes defensive null guard: ($scope.filteredObservationColumns || [])   
  
 2. **Refactored getTableInfo() Function**                                                                                             
  **Before**: Returned custom columns if configured, else hardcoded default columns with fixed column order                                              
  **After**:                                                                                                                                                                                                                                    
  - Checks both listViewTemplateUrl AND listViewColumns before using custom config                                                                   
      - If both configured → return custom columns                               
      - If neither or only one configured → build default structure                                                                                 
  - Default structure is now dynamic and composable:                                                                                                 
    a. Base columns: Identifier, Patient Name, Status                                                                                                
    b. Optional: ConceptFormatAttributeName (if configured)                                                                                          
    c. **Dynamic: Observation columns from listViewObservationColumns config**       ---> Key requirement                                                                    
    d. Standard surgical columns: Day, Date, Patient Age, Start Time, Est Time, Actual Time, OT#, Surgeon                                            
    e. Bed-related columns: Status Change Notes, Bed Location, Bed ID                                                                                
    f. Optional: Primary Diagnoses (if showPrimaryDiagnosisForOT is set)     
    
   Update for latest commit:
   - Whether a newly added Concept Format attribute should be mandatory will now be decided based on the configuration in config repo (requiredSurgeryAttributes field) and it won't be mandated by default.  