### PR TITLE
HIVE-123806 | Ramadevi Adepu |  Add stop reason support for VDP

### DIFF
--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -745,6 +745,8 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
             action: 'action',
             careSetting: 'careSetting',
             dateStopped: 'dateStopped',
+            orderReasonConcept: 'orderReasonConcept',
+            orderReasonText: 'orderReasonText',
             uuid: 'uuid',
             dateActivated: 'dateActivated',
             encounterUuid: 'encounterUuid',
@@ -869,8 +871,35 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
     viewModel.previousOrderUuid = drugOrderResponse.previousOrderUuid;
     viewModel.dateActivated = drugOrderResponse.dateActivated;
     viewModel.encounterUuid = drugOrderResponse.encounterUuid;
+    
+    // Preserve orderReasonConcept from existing viewModel if backend returns null or uuid string only
+    var existingReasonConcept = viewModel.orderReasonConcept;
     if (drugOrderResponse.orderReasonConcept) {
         viewModel.orderReasonConcept = drugOrderResponse.orderReasonConcept;
+        // If response has only uuid string, convert to object and preserve existing name/display
+        if (typeof viewModel.orderReasonConcept === 'string') {
+            var uuidOnly = viewModel.orderReasonConcept;
+            viewModel.orderReasonConcept = {
+                uuid: uuidOnly
+            };
+            if (existingReasonConcept && existingReasonConcept.name) {
+                viewModel.orderReasonConcept.name = existingReasonConcept.name;
+            }
+            if (existingReasonConcept && existingReasonConcept.display) {
+                viewModel.orderReasonConcept.display = existingReasonConcept.display;
+            }
+        } else if (typeof viewModel.orderReasonConcept === 'object') {
+            // If response has object but missing name/display, try to preserve from existing
+            if (existingReasonConcept && !viewModel.orderReasonConcept.name && existingReasonConcept.name) {
+                viewModel.orderReasonConcept.name = existingReasonConcept.name;
+            }
+            if (existingReasonConcept && !viewModel.orderReasonConcept.display && existingReasonConcept.display) {
+                viewModel.orderReasonConcept.display = existingReasonConcept.display;
+            }
+        }
+    } else if (!drugOrderResponse.orderReasonConcept && existingReasonConcept) {
+        // Backend returned null - keep the existing value from frontend (user's selection)
+        viewModel.orderReasonConcept = existingReasonConcept;
     }
     viewModel.orderReasonText = drugOrderResponse.orderReasonText;
     viewModel.orderNumber = drugOrderResponse.orderNumber && parseInt(drugOrderResponse.orderNumber.replace("ORD-", ""));

--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -887,7 +887,7 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
             if (existingReasonConcept && existingReasonConcept.display) {
                 viewModel.orderReasonConcept.display = existingReasonConcept.display;
             }
-        }  else if (angular.isObject(viewModel.orderReasonConcept)) {
+        } else if (angular.isObject(viewModel.orderReasonConcept)) {
             // If response has object but missing name/display, try to preserve from existing
             if (existingReasonConcept && !viewModel.orderReasonConcept.name && existingReasonConcept.name) {
                 viewModel.orderReasonConcept.name = existingReasonConcept.name;

--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -871,11 +871,9 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
     viewModel.previousOrderUuid = drugOrderResponse.previousOrderUuid;
     viewModel.dateActivated = drugOrderResponse.dateActivated;
     viewModel.encounterUuid = drugOrderResponse.encounterUuid;
-    // Preserve orderReasonConcept from existing viewModel if backend returns null or uuid string only
     var existingReasonConcept = viewModel.orderReasonConcept;
     if (drugOrderResponse.orderReasonConcept) {
         viewModel.orderReasonConcept = drugOrderResponse.orderReasonConcept;
-        // If response has only uuid string, convert to object and preserve existing name/display
         if (angular.isString(viewModel.orderReasonConcept)) {
             var uuidOnly = viewModel.orderReasonConcept;
             viewModel.orderReasonConcept = {
@@ -888,7 +886,6 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
                 viewModel.orderReasonConcept.display = existingReasonConcept.display;
             }
         } else if (angular.isObject(viewModel.orderReasonConcept)) {
-            // If response has object but missing name/display, try to preserve from existing
             if (existingReasonConcept && !viewModel.orderReasonConcept.name && existingReasonConcept.name) {
                 viewModel.orderReasonConcept.name = existingReasonConcept.name;
             }
@@ -897,7 +894,6 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
             }
         }
     } else if (!drugOrderResponse.orderReasonConcept && existingReasonConcept) {
-        // Backend returned null - keep the existing value from frontend (user's selection)
         viewModel.orderReasonConcept = existingReasonConcept;
     }
     viewModel.orderReasonText = drugOrderResponse.orderReasonText;

--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -871,13 +871,12 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
     viewModel.previousOrderUuid = drugOrderResponse.previousOrderUuid;
     viewModel.dateActivated = drugOrderResponse.dateActivated;
     viewModel.encounterUuid = drugOrderResponse.encounterUuid;
-    
     // Preserve orderReasonConcept from existing viewModel if backend returns null or uuid string only
     var existingReasonConcept = viewModel.orderReasonConcept;
     if (drugOrderResponse.orderReasonConcept) {
         viewModel.orderReasonConcept = drugOrderResponse.orderReasonConcept;
         // If response has only uuid string, convert to object and preserve existing name/display
-        if (typeof viewModel.orderReasonConcept === 'string') {
+        if (angular.isString(viewModel.orderReasonConcept)) {
             var uuidOnly = viewModel.orderReasonConcept;
             viewModel.orderReasonConcept = {
                 uuid: uuidOnly
@@ -888,7 +887,7 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
             if (existingReasonConcept && existingReasonConcept.display) {
                 viewModel.orderReasonConcept.display = existingReasonConcept.display;
             }
-        } else if (typeof viewModel.orderReasonConcept === 'object') {
+        }  else if (angular.isObject(viewModel.orderReasonConcept)) {
             // If response has object but missing name/display, try to preserve from existing
             if (existingReasonConcept && !viewModel.orderReasonConcept.name && existingReasonConcept.name) {
                 viewModel.orderReasonConcept.name = existingReasonConcept.name;

--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -871,30 +871,8 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
     viewModel.previousOrderUuid = drugOrderResponse.previousOrderUuid;
     viewModel.dateActivated = drugOrderResponse.dateActivated;
     viewModel.encounterUuid = drugOrderResponse.encounterUuid;
-    var existingReasonConcept = viewModel.orderReasonConcept;
     if (drugOrderResponse.orderReasonConcept) {
         viewModel.orderReasonConcept = drugOrderResponse.orderReasonConcept;
-        if (angular.isString(viewModel.orderReasonConcept)) {
-            var uuidOnly = viewModel.orderReasonConcept;
-            viewModel.orderReasonConcept = {
-                uuid: uuidOnly
-            };
-            if (existingReasonConcept && existingReasonConcept.name) {
-                viewModel.orderReasonConcept.name = existingReasonConcept.name;
-            }
-            if (existingReasonConcept && existingReasonConcept.display) {
-                viewModel.orderReasonConcept.display = existingReasonConcept.display;
-            }
-        } else if (angular.isObject(viewModel.orderReasonConcept)) {
-            if (existingReasonConcept && !viewModel.orderReasonConcept.name && existingReasonConcept.name) {
-                viewModel.orderReasonConcept.name = existingReasonConcept.name;
-            }
-            if (existingReasonConcept && !viewModel.orderReasonConcept.display && existingReasonConcept.display) {
-                viewModel.orderReasonConcept.display = existingReasonConcept.display;
-            }
-        }
-    } else if (!drugOrderResponse.orderReasonConcept && existingReasonConcept) {
-        viewModel.orderReasonConcept = existingReasonConcept;
     }
     viewModel.orderReasonText = drugOrderResponse.orderReasonText;
     viewModel.orderNumber = drugOrderResponse.orderNumber && parseInt(drugOrderResponse.orderNumber.replace("ORD-", ""));

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -774,11 +774,8 @@ angular.module('bahmni.clinical')
                             removableOrder.scheduledDate = discontinuedDrug.dateStopped;
                             removableOrder.dateStopped = discontinuedDrug.dateStopped;
 
-                            if (discontinuedDrug.orderReasonConcept && discontinuedDrug.orderReasonConcept.name) {
-                                removableOrder.orderReasonConcept = {
-                                    name: discontinuedDrug.orderReasonConcept.name.name,
-                                    uuid: discontinuedDrug.orderReasonConcept.uuid
-                                };
+                            if (discontinuedDrug.orderReasonConcept && discontinuedDrug.orderReasonConcept.uuid) {
+                                removableOrder.orderReasonConcept = discontinuedDrug.orderReasonConcept.uuid;
                             }
                         }
                         if (removableOrder) {

--- a/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
+++ b/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
@@ -237,6 +237,12 @@ angular.module('bahmni.clinical')
 
             $scope.getOrderReasonConcept = function (drugOrder) {
                 if (drugOrder.orderReasonConcept) {
+                    // Handle case where backend returns uuid string instead of object
+                    if (typeof drugOrder.orderReasonConcept === 'string') {
+                        // Look up the concept from stoppedOrderReasons array
+                        var reasonConcept = _.find($scope.stoppedOrderReasons, { uuid: drugOrder.orderReasonConcept });
+                        return reasonConcept ? (reasonConcept.display || reasonConcept.name) : drugOrder.orderReasonConcept;
+                    }
                     return drugOrder.orderReasonConcept.display || drugOrder.orderReasonConcept.name;
                 }
             };

--- a/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
+++ b/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
@@ -238,7 +238,7 @@ angular.module('bahmni.clinical')
             $scope.getOrderReasonConcept = function (drugOrder) {
                 if (drugOrder.orderReasonConcept) {
                     // Handle case where backend returns uuid string instead of object
-                    if (typeof drugOrder.orderReasonConcept === 'string') {
+                    if (angular.isString(drugOrder.orderReasonConcept)) {
                         // Look up the concept from stoppedOrderReasons array
                         var reasonConcept = _.find($scope.stoppedOrderReasons, { uuid: drugOrder.orderReasonConcept });
                         return reasonConcept ? (reasonConcept.display || reasonConcept.name) : drugOrder.orderReasonConcept;

--- a/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
+++ b/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
@@ -237,9 +237,7 @@ angular.module('bahmni.clinical')
 
             $scope.getOrderReasonConcept = function (drugOrder) {
                 if (drugOrder.orderReasonConcept) {
-                    // Handle case where backend returns uuid string instead of object
                     if (angular.isString(drugOrder.orderReasonConcept)) {
-                        // Look up the concept from stoppedOrderReasons array
                         var reasonConcept = _.find($scope.stoppedOrderReasons, { uuid: drugOrder.orderReasonConcept });
                         return reasonConcept ? (reasonConcept.display || reasonConcept.name) : drugOrder.orderReasonConcept;
                     }

--- a/ui/app/clinical/displaycontrols/treatmentData/views/treatmentTableRow.html
+++ b/ui/app/clinical/displaycontrols/treatmentData/views/treatmentTableRow.html
@@ -32,6 +32,10 @@
             <i class="fa fa-comments left"></i>
             <pre class="left">{{stage.additionalInstructions}}</pre>
         </span>
+        <div ng-if="drugOrder.isDiscontinuedOrStopped() && (drugOrder.orderReasonText || drugOrder.orderReasonConcept)" class="stopped-reason-block">
+            <div ng-if="drugOrder.orderReasonText">{{'MEDICATION_DUE_TO'|translate}} {{drugOrder.orderReasonText}}</div>
+            <div ng-if="drugOrder.orderReasonConcept && (drugOrder.orderReasonConcept.display || drugOrder.orderReasonConcept.name)">({{drugOrder.orderReasonConcept.display || drugOrder.orderReasonConcept.name}})</div>
+        </div>
         <div class="footer-note right">
             <span class="provider" ng-if="params.showProvider">
                 <provider-directive creator-name="{{drugOrder.creatorName}}" provider-name="{{drugOrder.provider.name}}" provider-date="::drugOrder.effectiveStartDate"></provider-directive>

--- a/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
+++ b/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
@@ -2164,6 +2164,23 @@ describe("AddTreatmentController", function () {
             expect(discontinuedDrugOrder.scheduledDate).toEqual(drugOrder.dateStopped);
             expect(discontinuedDrugOrder.dateActivated).toEqual(null);
         });
+
+        it("should map VDP stop reason concept uuid and text while saving discontinued orders", function () {
+            var drugOrder = Bahmni.Clinical.DrugOrderViewModel.createFromContract(activeDrugOrder);
+            drugOrder.orderReasonConcept = {
+                uuid: '6afc2690-12b2-11e6-8c00-080027d2adbd',
+                name: 'Allergic Reaction'
+            };
+            drugOrder.orderReasonText = 'Adverse reaction observed';
+
+            rootScope.$broadcast("event:discontinueDrugOrder", drugOrder);
+            scope.consultation.preSaveHandler.fire();
+
+            expect(scope.consultation.removableDrugs.length).toEqual(1);
+            var discontinuedDrugOrder = scope.consultation.removableDrugs[0];
+            expect(discontinuedDrugOrder.orderReasonConcept).toEqual('6afc2690-12b2-11e6-8c00-080027d2adbd');
+            expect(discontinuedDrugOrder.orderReasonText).toEqual('Adverse reaction observed');
+        });
     });
 
     describe("when undo removing", function () {

--- a/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
+++ b/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
@@ -370,6 +370,45 @@ describe("DrugOrderHistoryController", function () {
                 }
             })).toBe('Allergic Reaction');
         });
+
+        it("should lookup and return display text when concept is UUID string", function () {
+            treatmentConfig.stoppedOrderReasonConcepts = [
+                {
+                    uuid: '6afc2690-12b2-11e6-8c00-080027d2adbd',
+                    display: 'Allergic Reaction',
+                    name: 'Allergic Reaction'
+                },
+                {
+                    uuid: 'another-uuid-12b2-11e6-8c00-080027d2adbd',
+                    display: 'Adverse Event',
+                    name: 'Adverse Event'
+                }
+            ];
+            initController();
+
+            var result = scope.getOrderReasonConcept({
+                orderReasonConcept: '6afc2690-12b2-11e6-8c00-080027d2adbd'
+            });
+
+            expect(result).toBe('Allergic Reaction');
+        });
+
+        it("should return UUID string when UUID lookup fails", function () {
+            treatmentConfig.stoppedOrderReasonConcepts = [
+                {
+                    uuid: '6afc2690-12b2-11e6-8c00-080027d2adbd',
+                    display: 'Allergic Reaction',
+                    name: 'Allergic Reaction'
+                }
+            ];
+            initController();
+
+            var result = scope.getOrderReasonConcept({
+                orderReasonConcept: 'non-existent-uuid'
+            });
+
+            expect(result).toBe('non-existent-uuid');
+        });
     });
 
     it('should broadcast refillDrugOrder event on refill', function () {

--- a/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
+++ b/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
@@ -344,6 +344,34 @@ describe("DrugOrderHistoryController", function () {
         });
     });
 
+    describe("getOrderReasonConcept", function () {
+        it("should return reason display text by looking up stoppedOrderReasons when concept is uuid string", function () {
+            treatmentConfig.stoppedOrderReasonConcepts = [
+                {
+                    uuid: '6afc2690-12b2-11e6-8c00-080027d2adbd',
+                    display: 'Allergic Reaction',
+                    name: 'Allergic Reaction'
+                }
+            ];
+            initController();
+
+            var result = scope.getOrderReasonConcept({
+                orderReasonConcept: '6afc2690-12b2-11e6-8c00-080027d2adbd'
+            });
+
+            expect(result).toBe('Allergic Reaction');
+        });
+
+        it("should return display or name when concept is an object", function () {
+            expect(scope.getOrderReasonConcept({
+                orderReasonConcept: {
+                    display: 'Allergic Reaction',
+                    name: 'Allergic Reaction'
+                }
+            })).toBe('Allergic Reaction');
+        });
+    });
+
     it('should broadcast refillDrugOrder event on refill', function () {
         var drugOrder = Bahmni.Clinical.DrugOrderViewModel.createFromContract(prescribedDrugOrders[0]);
         scope.refill(drugOrder);

--- a/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
+++ b/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
@@ -1051,6 +1051,19 @@ describe("drugOrderViewModel", function () {
             expect(viewModel.stageCount).toBe(2);
             expect(viewModel.hasLoadingDose).toBe(true);
         });
+
+        it("should map stop reason concept and text for VDP contracts", function () {
+            var dosages = [
+                { sequence: 1, text: 'Stage 1', timing: { code: { text: 'Once a day' }, repeat: { duration: 3, durationUnit: 'd' } }, doseAndRate: [{ doseQuantity: { value: 5, unit: 'mg' } }], extension: [{ url: 'isLoadingDose', valueBoolean: false }], additionalInstruction: [], patientInstruction: '' }
+            ];
+            var contract = buildVdpContract(dosages);
+            contract.orderReasonConcept = '6afc2690-12b2-11e6-8c00-080027d2adbd';
+            contract.orderReasonText = 'Adverse reaction observed';
+
+            var viewModel = Bahmni.Clinical.DrugOrderViewModel.createFromContract(contract);
+            expect(viewModel.orderReasonConcept).toBe('6afc2690-12b2-11e6-8c00-080027d2adbd');
+            expect(viewModel.orderReasonText).toBe('Adverse reaction observed');
+        });
     });
 
     describe("createFromContract - VDP orders should not have parent-level instructions", function () {


### PR DESCRIPTION
## Summary
- Added stop reason support for Variable Dosage Protocol (VDP) orders.
- Added order reason concept and order reason text handling in drug order view model.
- Updated treatment and drug order history flow to preserve stop reason details.

## Testing
- Verified VDP stop reason changes locally.
HIve:https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=b3vHbfQy9vXbfcFCx