### PR TITLE
HIVE-101153 | Nandini | Fix top content hidden on General dashboard after visiting Medication tab

### DIFF
--- a/ui/app/common/displaycontrols/dashboard/directives/dashboard.js
+++ b/ui/app/common/displaycontrols/dashboard/directives/dashboard.js
@@ -1,14 +1,17 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.dashboard')
-    .directive('dashboard', ['appService', '$stateParams', '$bahmniCookieStore', 'configurations', 'encounterService', 'spinner', 'auditLogService', 'messagingService', '$state', '$translate', 'formPrintService', 'formDraftService', function (appService, $stateParams, $bahmniCookieStore, configurations, encounterService, spinner, auditLogService, messagingService, $state, $translate, formPrintService, formDraftService) {
+    .directive('dashboard', ['appService', '$bahmniCookieStore', 'configurations', 'encounterService', 'spinner', 'auditLogService', 'messagingService', '$state', '$translate', 'formPrintService', 'formDraftService', function (appService, $bahmniCookieStore, configurations, encounterService, spinner, auditLogService, messagingService, $state, $translate, formPrintService, formDraftService) {
         var controller = function ($scope, $filter, $rootScope) {
             var dashboardConfig = null;
 
             var init = function () {
                 $scope.dashboard = Bahmni.Common.DisplayControl.Dashboard.create($scope.config || {}, $filter);
             };
-            $scope.tabConfigName = $stateParams.tabConfigName || 'default';
+            $scope.tabConfigName = $state.params.tabConfigName || 'default';
+            var cleanUpStateChange = $rootScope.$on('$stateChangeSuccess', function () {
+                $scope.tabConfigName = $state.params.tabConfigName || 'default';
+            });
 
             var findFormV2ReactConfig = function (sections) {
                 if (!sections || sections.length === 0) {
@@ -157,6 +160,7 @@ angular.module('bahmni.common.displaycontrol.dashboard')
             };
             var unbindWatch = $scope.$watch('config', init);
             $scope.$on("$stateChangeStart", unbindWatch);
+            $scope.$on('$destroy', cleanUpStateChange);
         };
 
         return {

--- a/ui/test/unit/common/displaycontrols/dashboard/Directives/dashboard.spec.js
+++ b/ui/test/unit/common/displaycontrols/dashboard/Directives/dashboard.spec.js
@@ -24,7 +24,7 @@ describe('Dashboard', function () {
         $provide.value('spinner', {});
         $provide.value('auditLogService', {});
         $provide.value('messagingService', {});
-        $provide.value('$state', {});
+        $provide.value('$state', {params: {tabConfigName: 'default'}});
         $provide.value('$translate', {});
         $provide.value('formPrintService', formPrintService);
         $provide.value('formDraftService', {getFormNamesFromDraft: function () { return []; }});


### PR DESCRIPTION
## Problem : 
The top section of the Patient Dashboard was not visible when users
navigated from Orders → Medication dashboard to the General dashboard.

## Root Cause
 - The dashboard used a value called `tabConfigName` to decide the page layout.
    It was read only once when the page opened.
- If the page opened on the Medication tab, it kept the Medication value even
   after switching to General. That removed the top margin the General page
  needs, so the content slid underneath the fixed patient-info bar and the top
   was cut off.
## Changes
- `dashboard.js`
  - Read `tabConfigName` from `$state.params`
  - Updated it on every tab/page change so the layout always matches the
    current page
  - Cleaned up the listener when the directive is destroyed
- `dashboard.spec.js`
  - Updated the `$state` mock to match the new code
