### PR TITLE
HIVE-121640|Karthik|Fix phantom validation blocking saves on deleted forms

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -232,7 +232,12 @@ angular.module('bahmni.clinical')
                         return draftObs.formNamespace === 'Bahmni' && draftObs.formFieldPath;
                     });
                     if (form2DraftObs.length > 0) {
+                        var deletedFormIds = $rootScope.deletedFormIds || [];
                         _.each($scope.consultation.observationForms, function (obsForm) {
+                            var obsFormId = obsForm.formUuid || obsForm.uuid || obsForm.id;
+                            if (obsFormId && _.includes(deletedFormIds, obsFormId)) {
+                                return;
+                            }
                             var matchingObs = _.filter(form2DraftObs, function (draftObs) {
                                 return draftObs.formFieldPath.split('.')[0] === obsForm.formName;
                             });
@@ -509,6 +514,9 @@ angular.module('bahmni.clinical')
 
                 var deletedFormIds = $rootScope.deletedFormIds || [];
                 collectedObs = _.filter(collectedObs, function (obs) {
+                    if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
+                        return false;
+                    }
                     if (obs.formFieldPath) {
                         var formName = obs.formFieldPath.split('.')[0];
                         var isDeletedForm = _.find($scope.consultation.observationForms, function (form) {

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -20,18 +20,62 @@ angular.module('bahmni.clinical')
             var customRepresentation = Bahmni.ConceptSet.CustomRepresentationBuilder.build(fields, 'setMembers', numberOfLevels);
             var allConceptSections = [];
 
-            var init = function () {
-                $rootScope.deletedFormIds = $scope.consultation && $scope.consultation.deletedFormIds ? $scope.consultation.deletedFormIds.slice() : [];
+            var getDeletedFormIds = function () {
+                return $scope.consultation && $scope.consultation.deletedFormIds ? $scope.consultation.deletedFormIds.slice() : [];
+            };
 
+            var getRootDeletedFormIds = function () {
+                return getDeletedFormIds();
+            };
+
+            var getFormId = function (form) {
+                return form.formUuid || form.uuid || form.id;
+            };
+
+            var isObservationFromDeletedForm = function (obs, deletedFormIds) {
+                if (!obs) return false;
+                if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
+                    return true;
+                }
+                if (obs.formFieldPath) {
+                    var formName = obs.formFieldPath.split('.')[0];
+                    return _.find($scope.consultation.observationForms, function (form) {
+                        var formId = getFormId(form);
+                        return formId && _.includes(deletedFormIds, formId) && form.formName === formName;
+                    });
+                }
+                return false;
+            };
+
+            var clearTemplateAddedState = function (template) {
+                if (!template) return;
+                template.isAdded = false;
+                template.isOpen = false;
+                template.klass = "";
+                template.isLoaded = false;
+            };
+
+            var isTemplateSelected = function (template) {
+                return _.find($scope.consultation.selectedObsTemplate, function (t) {
+                    return t === template;
+                });
+            };
+
+            var activateTemplate = function (template) {
+                template.isOpen = true;
+                template.isLoaded = true;
+                template.klass = "active";
+            };
+
+            var init = function () {
                 if ($rootScope.draftDiscarded) {
-                    var preservedDeletedFormIds = $scope.consultation && $scope.consultation.deletedFormIds ? $scope.consultation.deletedFormIds.slice() : [];
+                    var preservedDeletedFormIds = getDeletedFormIds();
                     $scope.allTemplates = [];
                     $scope.consultation.selectedObsTemplate = [];
                     $scope.consultation.observationForms = [];
                     $rootScope.draftDiscarded = false;
                     if (preservedDeletedFormIds && preservedDeletedFormIds.length > 0) {
                         $scope.consultation.deletedFormIds = preservedDeletedFormIds;
-                        $rootScope.deletedFormIds = preservedDeletedFormIds;
                     }
                 }
 
@@ -120,14 +164,11 @@ angular.module('bahmni.clinical')
 
                 $scope.allTemplates = getSelectedObsTemplate(allConceptSections);
 
-                var deletedFormIds = $rootScope.deletedFormIds || [];
+                var deletedFormIds = getRootDeletedFormIds();
                 _.each($scope.allTemplates, function (template) {
-                    var templateId = template.formUuid || template.uuid || template.id;
+                    var templateId = getFormId(template);
                     if (templateId && _.includes(deletedFormIds, templateId)) {
-                        template.isAdded = false;
-                        template.isOpen = false;
-                        template.klass = "";
-                        template.isLoaded = false;
+                        clearTemplateAddedState(template);
                     }
                 });
 
@@ -137,18 +178,13 @@ angular.module('bahmni.clinical')
                 $scope.allTemplates = $scope.allTemplates.concat(observationFormsToAdd);
 
                 _.each(observationFormsToAdd, function (form) {
-                    var formId = form.formUuid || form.uuid || form.id;
+                    var formId = getFormId(form);
                     if (formId && _.includes(deletedFormIds, formId)) {
-                        form.isAdded = false;
-                        form.isOpen = false;
-                        form.klass = "";
-                        form.isLoaded = false;
+                        clearTemplateAddedState(form);
                     }
                 });
 
-                $scope.allTemplates = _.uniqBy($scope.allTemplates, function (t) {
-                    return t.formUuid || t.uuid || t.id;
-                });
+                $scope.allTemplates = _.uniqBy($scope.allTemplates, getFormId);
 
                 $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');
 
@@ -164,27 +200,16 @@ angular.module('bahmni.clinical')
                     clearStaleObsFromTemplates();
                 }
 
-                var deletedFormIds = $rootScope.deletedFormIds || [];
+                var deletedFormIds = getRootDeletedFormIds();
                 if (deletedFormIds.length > 0) {
                     if ($scope.consultation.observations) {
                         $scope.consultation.observations = _.filter($scope.consultation.observations, function (obs) {
-                            if (!obs) return true;
-                            if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
-                                return false;
-                            }
-                            if (obs.formFieldPath) {
-                                var formName = obs.formFieldPath.split('.')[0];
-                                return !_.find($scope.consultation.observationForms, function (form) {
-                                    var formId = form.formUuid || form.uuid || form.id;
-                                    return formId && _.includes(deletedFormIds, formId) && form.formName === formName;
-                                });
-                            }
-                            return true;
+                            return !isObservationFromDeletedForm(obs, deletedFormIds);
                         });
                     }
                     if ($scope.allTemplates) {
                         _.each($scope.allTemplates, function (template) {
-                            var templateId = template.uuid || template.formUuid || template.id;
+                            var templateId = getFormId(template);
                             if (templateId && _.includes(deletedFormIds, templateId)) {
                                 template.observations = [];
                             }
@@ -232,9 +257,9 @@ angular.module('bahmni.clinical')
                         return draftObs.formNamespace === 'Bahmni' && draftObs.formFieldPath;
                     });
                     if (form2DraftObs.length > 0) {
-                        var deletedFormIds = $rootScope.deletedFormIds || [];
+                        var deletedFormIds = getRootDeletedFormIds();
                         _.each($scope.consultation.observationForms, function (obsForm) {
-                            var obsFormId = obsForm.formUuid || obsForm.uuid || obsForm.id;
+                            var obsFormId = getFormId(obsForm);
                             if (obsFormId && _.includes(deletedFormIds, obsFormId)) {
                                 return;
                             }
@@ -297,24 +322,12 @@ angular.module('bahmni.clinical')
                     }
                 });
                 if ($scope.consultation.observations) {
-                    var deletedFormIds = $rootScope.deletedFormIds || [];
+                    var deletedFormIds = getRootDeletedFormIds();
                     dirtyTrackingState.extraObservations = _.filter($scope.consultation.observations, function (obs) {
                         if (!obs.uuid || trackedObsUuids.has(obs.uuid)) {
                             return false;
                         }
-                        if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
-                            return false;
-                        }
-                        if (obs.formFieldPath) {
-                            var formName = obs.formFieldPath.split('.')[0];
-                            var isDeletedForm = _.find($scope.consultation.observationForms, function (form) {
-                                return _.includes(deletedFormIds, form.formUuid || form.uuid || form.id) && form.formName === formName;
-                            });
-                            if (isDeletedForm) {
-                                return false;
-                            }
-                        }
-                        return true;
+                        return !isObservationFromDeletedForm(obs, deletedFormIds);
                     });
                 }
 
@@ -325,10 +338,10 @@ angular.module('bahmni.clinical')
 
                 if (formUuidParam) {
                     var targetForm = _.find($scope.allTemplates, function (t) {
-                        return t.formUuid === formUuidParam;
+                        return getFormId(t) === formUuidParam;
                     });
                     if (targetForm) {
-                        var deletedFormIds = $rootScope.deletedFormIds || [];
+                        var deletedFormIds = getRootDeletedFormIds();
                         if (!_.includes(deletedFormIds, formUuidParam) && !_.find($scope.consultation.selectedObsTemplate, function (t) { return t === targetForm; })) {
                             targetForm.isAdded = true;
                             $scope.consultation.selectedObsTemplate.push(targetForm);
@@ -379,14 +392,11 @@ angular.module('bahmni.clinical')
             };
 
             var insertInDefaultOrder = function () {
-                var deletedFormIds = $rootScope.deletedFormIds || [];
+                var deletedFormIds = getRootDeletedFormIds();
                 _.each($scope.allTemplates, function (template) {
                     if (template.observations.length > 0) {
-                        var templateId = template.formUuid || template.uuid || template.id;
-                        var isInSelectedTemplates = _.find($scope.consultation.selectedObsTemplate, function (t) {
-                            return t === template;
-                        });
-                        if (!templateId || (!_.includes(deletedFormIds, templateId) && !isInSelectedTemplates)) {
+                        var templateId = getFormId(template);
+                        if (!templateId || (!_.includes(deletedFormIds, templateId) && !isTemplateSelected(template))) {
                             insertTemplate(template);
                         }
                     }
@@ -395,14 +405,11 @@ angular.module('bahmni.clinical')
 
             var insertTemplate = function (template) {
                 if (template && !(template.isDefault() || template.alwaysShow)) {
-                    var isAlreadySelected = _.find($scope.consultation.selectedObsTemplate, function (t) {
-                        return t === template;
-                    });
-                    if (isAlreadySelected) {
+                    if (isTemplateSelected(template)) {
                         return;
                     }
-                    var deletedFormIds = $rootScope.deletedFormIds || [];
-                    var templateId = template.formUuid || template.uuid || template.id;
+                    var deletedFormIds = getRootDeletedFormIds();
+                    var templateId = getFormId(template);
                     if (!templateId || !_.includes(deletedFormIds, templateId)) {
                         $scope.consultation.selectedObsTemplate.push(template);
                     }
@@ -416,13 +423,11 @@ angular.module('bahmni.clinical')
             };
 
             var openTemplate = function (template) {
-                template.isOpen = true;
-                template.isLoaded = true;
-                template.klass = "active";
+                activateTemplate(template);
             };
 
             var initializeDefaultTemplates = function () {
-                var deletedFormIds = $rootScope.deletedFormIds || [];
+                var deletedFormIds = getRootDeletedFormIds();
                 var currentlySelected = _.clone($scope.consultation.selectedObsTemplate) || [];
                 $scope.consultation.selectedObsTemplate = _.filter($scope.allTemplates, function (template) {
                     var isCurrentlySelected = _.find(currentlySelected, function (t) {
@@ -432,7 +437,7 @@ angular.module('bahmni.clinical')
                         return true;
                     }
                     if (template.isDefault() || template.alwaysShow) {
-                        var templateId = template.formUuid || template.uuid || template.id;
+                        var templateId = getFormId(template);
                         if (templateId && _.includes(deletedFormIds, templateId)) {
                             return false;
                         }
@@ -512,21 +517,9 @@ angular.module('bahmni.clinical')
                     });
                 }
 
-                var deletedFormIds = $rootScope.deletedFormIds || [];
+                var deletedFormIds = getRootDeletedFormIds();
                 collectedObs = _.filter(collectedObs, function (obs) {
-                    if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
-                        return false;
-                    }
-                    if (obs.formFieldPath) {
-                        var formName = obs.formFieldPath.split('.')[0];
-                        var isDeletedForm = _.find($scope.consultation.observationForms, function (form) {
-                            return _.includes(deletedFormIds, form.formUuid || form.uuid || form.id) && form.formName === formName;
-                        });
-                        if (isDeletedForm) {
-                            return false;
-                        }
-                    }
-                    return true;
+                    return !isObservationFromDeletedForm(obs, deletedFormIds);
                 });
 
                 $scope.consultation.observations = collectedObs;
@@ -552,8 +545,8 @@ angular.module('bahmni.clinical')
 
             $scope.addTemplate = function (template) {
                 var templateId = template.formUuid || template.uuid || template.id;
-                if (templateId && $rootScope.deletedFormIds) {
-                    $rootScope.deletedFormIds = _.filter($rootScope.deletedFormIds, function (id) {
+                if (templateId && $scope.consultation && $scope.consultation.deletedFormIds) {
+                    $scope.consultation.deletedFormIds = _.filter($scope.consultation.deletedFormIds, function (id) {
                         return id !== templateId;
                     });
                 }

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -21,6 +21,8 @@ angular.module('bahmni.clinical')
             var allConceptSections = [];
 
             var init = function () {
+                $rootScope.deletedFormIds = $scope.consultation && $scope.consultation.deletedFormIds ? $scope.consultation.deletedFormIds.slice() : [];
+
                 if ($rootScope.draftDiscarded) {
                     var preservedDeletedFormIds = $scope.consultation && $scope.consultation.deletedFormIds ? $scope.consultation.deletedFormIds.slice() : [];
                     $scope.allTemplates = [];
@@ -29,6 +31,7 @@ angular.module('bahmni.clinical')
                     $rootScope.draftDiscarded = false;
                     if (preservedDeletedFormIds && preservedDeletedFormIds.length > 0) {
                         $scope.consultation.deletedFormIds = preservedDeletedFormIds;
+                        $rootScope.deletedFormIds = preservedDeletedFormIds;
                     }
                 }
 
@@ -165,13 +168,15 @@ angular.module('bahmni.clinical')
                 if (deletedFormIds.length > 0) {
                     if ($scope.consultation.observations) {
                         $scope.consultation.observations = _.filter($scope.consultation.observations, function (obs) {
+                            if (!obs) return true;
                             if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
                                 return false;
                             }
                             if (obs.formFieldPath) {
                                 var formName = obs.formFieldPath.split('.')[0];
                                 return !_.find($scope.consultation.observationForms, function (form) {
-                                    return (form.formUuid && _.includes(deletedFormIds, form.formUuid)) && form.formName === formName;
+                                    var formId = form.formUuid || form.uuid || form.id;
+                                    return formId && _.includes(deletedFormIds, formId) && form.formName === formName;
                                 });
                             }
                             return true;

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -22,11 +22,16 @@ angular.module('bahmni.clinical')
 
             var init = function () {
                 if ($rootScope.draftDiscarded) {
+                    var preservedDeletedFormIds = $scope.consultation && $scope.consultation.deletedFormIds ? $scope.consultation.deletedFormIds.slice() : [];
                     $scope.allTemplates = [];
                     $scope.consultation.selectedObsTemplate = [];
                     $scope.consultation.observationForms = [];
                     $rootScope.draftDiscarded = false;
+                    if (preservedDeletedFormIds && preservedDeletedFormIds.length > 0) {
+                        $scope.consultation.deletedFormIds = preservedDeletedFormIds;
+                    }
                 }
+
                 if (!($scope.allTemplates !== undefined && $scope.allTemplates.length > 0)) {
                     spinner.forPromise(conceptSetService.getConcept({
                         name: "All Observation Templates",
@@ -111,11 +116,38 @@ angular.module('bahmni.clinical')
                 };
 
                 $scope.allTemplates = getSelectedObsTemplate(allConceptSections);
+
+                var deletedFormIds = $rootScope.deletedFormIds || [];
+                _.each($scope.allTemplates, function (template) {
+                    var templateId = template.formUuid || template.uuid || template.id;
+                    if (templateId && _.includes(deletedFormIds, templateId)) {
+                        template.isAdded = false;
+                        template.isOpen = false;
+                        template.klass = "";
+                        template.isLoaded = false;
+                    }
+                });
+
                 $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');
-                $scope.allTemplates = $scope.allTemplates.concat($scope.consultation.observationForms);
+
+                var observationFormsToAdd = $scope.consultation.observationForms || [];
+                $scope.allTemplates = $scope.allTemplates.concat(observationFormsToAdd);
+
+                _.each(observationFormsToAdd, function (form) {
+                    var formId = form.formUuid || form.uuid || form.id;
+                    if (formId && _.includes(deletedFormIds, formId)) {
+                        form.isAdded = false;
+                        form.isOpen = false;
+                        form.klass = "";
+                        form.isLoaded = false;
+                    }
+                });
+
                 $scope.allTemplates = _.uniqBy($scope.allTemplates, function (t) {
                     return t.formUuid || t.uuid || t.id;
                 });
+
+                $scope.uniqueTemplates = _.uniqBy($scope.allTemplates, 'label');
 
                 var currentPatientUuid = $scope.patient ? $scope.patient.uuid : null;
                 var isDraftResumeValid = $rootScope.resumeDraftOnLoad &&
@@ -127,6 +159,32 @@ angular.module('bahmni.clinical')
                 // was false (including during active-visit cross-module navigation), wiping unsaved forms.
                 if (!isDraftResumeValid && $scope.visitHistory && !$scope.visitHistory.activeVisit) {
                     clearStaleObsFromTemplates();
+                }
+
+                var deletedFormIds = $rootScope.deletedFormIds || [];
+                if (deletedFormIds.length > 0) {
+                    if ($scope.consultation.observations) {
+                        $scope.consultation.observations = _.filter($scope.consultation.observations, function (obs) {
+                            if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
+                                return false;
+                            }
+                            if (obs.formFieldPath) {
+                                var formName = obs.formFieldPath.split('.')[0];
+                                return !_.find($scope.consultation.observationForms, function (form) {
+                                    return (form.formUuid && _.includes(deletedFormIds, form.formUuid)) && form.formName === formName;
+                                });
+                            }
+                            return true;
+                        });
+                    }
+                    if ($scope.allTemplates) {
+                        _.each($scope.allTemplates, function (template) {
+                            var templateId = template.uuid || template.formUuid || template.id;
+                            if (templateId && _.includes(deletedFormIds, templateId)) {
+                                template.observations = [];
+                            }
+                        });
+                    }
                 }
 
                 var draftFormData = isDraftResumeValid && $rootScope.draftData.formData ? $rootScope.draftData.formData : null;
@@ -229,8 +287,24 @@ angular.module('bahmni.clinical')
                     }
                 });
                 if ($scope.consultation.observations) {
+                    var deletedFormIds = $rootScope.deletedFormIds || [];
                     dirtyTrackingState.extraObservations = _.filter($scope.consultation.observations, function (obs) {
-                        return obs.uuid && !trackedObsUuids.has(obs.uuid);
+                        if (!obs.uuid || trackedObsUuids.has(obs.uuid)) {
+                            return false;
+                        }
+                        if (obs.concept && obs.concept.uuid && _.includes(deletedFormIds, obs.concept.uuid)) {
+                            return false;
+                        }
+                        if (obs.formFieldPath) {
+                            var formName = obs.formFieldPath.split('.')[0];
+                            var isDeletedForm = _.find($scope.consultation.observationForms, function (form) {
+                                return _.includes(deletedFormIds, form.formUuid || form.uuid || form.id) && form.formName === formName;
+                            });
+                            if (isDeletedForm) {
+                                return false;
+                            }
+                        }
+                        return true;
                     });
                 }
 
@@ -244,13 +318,14 @@ angular.module('bahmni.clinical')
                         return t.formUuid === formUuidParam;
                     });
                     if (targetForm) {
-                        if (!_.find($scope.consultation.selectedObsTemplate, function (t) { return t === targetForm; })) {
+                        var deletedFormIds = $rootScope.deletedFormIds || [];
+                        if (!_.includes(deletedFormIds, formUuidParam) && !_.find($scope.consultation.selectedObsTemplate, function (t) { return t === targetForm; })) {
                             targetForm.isAdded = true;
                             $scope.consultation.selectedObsTemplate.push(targetForm);
+                            $timeout(function () {
+                                $rootScope.$broadcast('event:openFormByUuid', { form: targetForm });
+                            }, 0);
                         }
-                        $timeout(function () {
-                            $rootScope.$broadcast('event:openFormByUuid', { form: targetForm });
-                        }, 0);
                     } else {
                         messagingService.showMessage('error', 'Form not found. Please contact your administrator.');
                     }
@@ -294,16 +369,33 @@ angular.module('bahmni.clinical')
             };
 
             var insertInDefaultOrder = function () {
+                var deletedFormIds = $rootScope.deletedFormIds || [];
                 _.each($scope.allTemplates, function (template) {
                     if (template.observations.length > 0) {
-                        insertTemplate(template);
+                        var templateId = template.formUuid || template.uuid || template.id;
+                        var isInSelectedTemplates = _.find($scope.consultation.selectedObsTemplate, function (t) {
+                            return t === template;
+                        });
+                        if (!templateId || (!_.includes(deletedFormIds, templateId) && !isInSelectedTemplates)) {
+                            insertTemplate(template);
+                        }
                     }
                 });
             };
 
             var insertTemplate = function (template) {
                 if (template && !(template.isDefault() || template.alwaysShow)) {
-                    $scope.consultation.selectedObsTemplate.push(template);
+                    var isAlreadySelected = _.find($scope.consultation.selectedObsTemplate, function (t) {
+                        return t === template;
+                    });
+                    if (isAlreadySelected) {
+                        return;
+                    }
+                    var deletedFormIds = $rootScope.deletedFormIds || [];
+                    var templateId = template.formUuid || template.uuid || template.id;
+                    if (!templateId || !_.includes(deletedFormIds, templateId)) {
+                        $scope.consultation.selectedObsTemplate.push(template);
+                    }
                 }
             };
 
@@ -320,8 +412,23 @@ angular.module('bahmni.clinical')
             };
 
             var initializeDefaultTemplates = function () {
+                var deletedFormIds = $rootScope.deletedFormIds || [];
+                var currentlySelected = _.clone($scope.consultation.selectedObsTemplate) || [];
                 $scope.consultation.selectedObsTemplate = _.filter($scope.allTemplates, function (template) {
-                    return template.isDefault() || template.alwaysShow;
+                    var isCurrentlySelected = _.find(currentlySelected, function (t) {
+                        return t === template;
+                    });
+                    if (isCurrentlySelected) {
+                        return true;
+                    }
+                    if (template.isDefault() || template.alwaysShow) {
+                        var templateId = template.formUuid || template.uuid || template.id;
+                        if (templateId && _.includes(deletedFormIds, templateId)) {
+                            return false;
+                        }
+                        return true;
+                    }
+                    return false;
                 });
             };
 
@@ -395,6 +502,20 @@ angular.module('bahmni.clinical')
                     });
                 }
 
+                var deletedFormIds = $rootScope.deletedFormIds || [];
+                collectedObs = _.filter(collectedObs, function (obs) {
+                    if (obs.formFieldPath) {
+                        var formName = obs.formFieldPath.split('.')[0];
+                        var isDeletedForm = _.find($scope.consultation.observationForms, function (form) {
+                            return _.includes(deletedFormIds, form.formUuid || form.uuid || form.id) && form.formName === formName;
+                        });
+                        if (isDeletedForm) {
+                            return false;
+                        }
+                    }
+                    return true;
+                });
+
                 $scope.consultation.observations = collectedObs;
             };
 
@@ -417,6 +538,13 @@ angular.module('bahmni.clinical')
             };
 
             $scope.addTemplate = function (template) {
+                var templateId = template.formUuid || template.uuid || template.id;
+                if (templateId && $rootScope.deletedFormIds) {
+                    $rootScope.deletedFormIds = _.filter($rootScope.deletedFormIds, function (id) {
+                        return id !== templateId;
+                    });
+                }
+
                 $scope.scrollingEnabled = true;
                 $scope.showTemplatesList = false;
                 var index = _.findLastIndex($scope.consultation.selectedObsTemplate, function (consultationTemplate) {

--- a/ui/app/common/auth/authentication.js
+++ b/ui/app/common/auth/authentication.js
@@ -227,7 +227,7 @@ angular.module('authentication')
         return {
             authenticateUser: authenticateUser
         };
-    }]).factory('logoutService', ['$rootScope', 'sessionService', '$window', 'auditLogService', 'formDraftService', 'ngDialog', 'appService', '$log', function ($rootScope, sessionService, $window, auditLogService, formDraftService, ngDialog, appService, $log) {
+    }]).factory('logoutService', ['$rootScope', 'sessionService', '$window', 'auditLogService', 'formDraftService', 'ngDialog', '$log', function ($rootScope, sessionService, $window, auditLogService, formDraftService, ngDialog, $log) {
         var isAttemptingLogout = false;
         function logoutUser () {
             auditLogService.log(undefined, 'USER_LOGOUT_SUCCESS', undefined, 'MODULE_LABEL_LOGOUT_KEY').then(function () {
@@ -255,8 +255,7 @@ angular.module('authentication')
         }
 
         function isLogoutDraftsWarningEnabled () {
-            var appDescriptor = appService.getAppDescriptor();
-            return !!(appDescriptor && appDescriptor.getConfigValue('enableFormDraftFeature'));
+            return !!$rootScope.formDraftFeatureEnabled;
         }
 
         function attemptLogout (scope) {

--- a/ui/app/common/concept-set/directives/conceptSetGroup.js
+++ b/ui/app/common/concept-set/directives/conceptSetGroup.js
@@ -176,11 +176,17 @@ angular.module('bahmni.common.conceptSet')
                 }
 
                 if ($scope.consultation && $scope.consultation.observationForms) {
-                    _.each($scope.consultation.observationForms, function (observationForm) {
-                        if (isTemplateMatch(observationForm, templateId)) {
-                            clearTemplateState(observationForm);
-                        }
-                    });
+                    if (!isFormPinned) {
+                        _.remove($scope.consultation.observationForms, function (observationForm) {
+                            return isTemplateMatch(observationForm, templateId);
+                        });
+                    } else {
+                        _.each($scope.consultation.observationForms, function (observationForm) {
+                            if (isTemplateMatch(observationForm, templateId)) {
+                                clearTemplateState(observationForm);
+                            }
+                        });
+                    }
                 }
 
                 if ($scope.consultation && ($scope.consultation.lastvisited === currentTemplate.id || $scope.consultation.lastvisited === currentTemplate.formUuid)) {
@@ -193,24 +199,6 @@ angular.module('bahmni.common.conceptSet')
                 }
 
                 messagingService.showMessage("info", $translate.instant("CLINICAL_TEMPLATE_REMOVED_SUCCESS_KEY", {label: label}));
-
-                var parentScope = $scope.$parent;
-                while (parentScope && !parentScope.allTemplates) {
-                    parentScope = parentScope.$parent;
-                }
-                if (parentScope && parentScope.allTemplates) {
-                    if (!isFormPinned) {
-                        _.remove(parentScope.allTemplates, function (template) {
-                            return isTemplateMatch(template, templateId);
-                        });
-                    } else {
-                        _.each(parentScope.allTemplates, function (template) {
-                            if (isTemplateMatch(template, templateId)) {
-                                clearTemplateState(template);
-                            }
-                        });
-                    }
-                }
             };
 
             $scope.openActiveForm = function (conceptSet) {

--- a/ui/app/common/concept-set/directives/conceptSetGroup.js
+++ b/ui/app/common/concept-set/directives/conceptSetGroup.js
@@ -9,7 +9,7 @@ angular.module('bahmni.common.conceptSet')
                   conceptSetUiConfigService, $timeout, clinicalAppConfigService, $stateParams, $translate, $state) {
             var conceptSetUIConfig = conceptSetUiConfigService.getConfig();
             var init = function () {
-                $scope.validationHandler = new Bahmni.ConceptSet.ConceptSetGroupPanelViewValidationHandler($scope.allTemplates);
+                $scope.validationHandler = new Bahmni.ConceptSet.ConceptSetGroupPanelViewValidationHandler($scope.allTemplates, $scope.consultation);
                 contextChangeHandler.add($scope.validationHandler.validate);
             };
             $scope.toggleSideBar = function () {
@@ -113,26 +113,100 @@ angular.module('bahmni.common.conceptSet')
                 return false;
             };
 
+            var clearTemplateState = function (template) {
+                template.observations = [];
+                template.hasUnsavedFormObservations = false;
+                template.draftValidationPassed = undefined;
+                template.validate = null;
+                template.component = null;
+                template.errorMessage = null;
+                template.isValid = undefined;
+                template.isOpen = false;
+                template.klass = "";
+                template.isLoaded = false;
+                if (template.formUuid) {
+                    template.formData = null;
+                }
+            };
+
+            var isTemplateMatch = function (template, templateId) {
+                return (template.uuid || template.formUuid || template.id) === templateId;
+            };
+
             $scope.remove = function (index) {
                 var label = $scope.allTemplates[index].label;
                 var currentTemplate = $scope.allTemplates[index];
-                var anotherTemplate = _.find($scope.allTemplates, function (template) {
-                    return template.label == currentTemplate.label && template !== currentTemplate;
-                });
-                if (anotherTemplate) {
-                    $scope.allTemplates.splice(index, 1);
+                var templateId = currentTemplate.uuid || currentTemplate.formUuid || currentTemplate.id;
+                var isFormPinned = currentTemplate.alwaysShow;
+
+                clearTemplateState(currentTemplate);
+
+                if (!isFormPinned) {
+                    if (!$rootScope.deletedFormIds) {
+                        $rootScope.deletedFormIds = [];
+                    }
+                    if (!_.includes($rootScope.deletedFormIds, templateId)) {
+                        $rootScope.deletedFormIds.push(templateId);
+                    }
+
+                    _.remove($scope.allTemplates, function (template) {
+                        return isTemplateMatch(template, templateId);
+                    });
+                    if ($scope.consultation && $scope.consultation.selectedObsTemplate) {
+                        _.remove($scope.consultation.selectedObsTemplate, function (template) {
+                            return isTemplateMatch(template, templateId);
+                        });
+                    }
                 }
-                else {
-                    $scope.allTemplates[index].isAdded = false;
-                    var clonedObj = $scope.allTemplates[index].clone();
-                    $scope.allTemplates[index] = clonedObj;
-                    $scope.allTemplates[index].isAdded = false;
-                    $scope.allTemplates[index].isOpen = false;
-                    $scope.allTemplates[index].klass = "";
-                    $scope.allTemplates[index].isLoaded = false;
+
+                if ($scope.consultation && $scope.consultation.observations) {
+                    $scope.consultation.observations = _.filter($scope.consultation.observations, function (observation) {
+                        if (observation.concept && observation.concept.uuid === templateId) {
+                            return false;
+                        }
+                        if (observation.formFieldPath && currentTemplate.formName) {
+                            return !observation.formFieldPath.startsWith(currentTemplate.formName + '.');
+                        }
+                        return true;
+                    });
                 }
-                $scope.leftPanelConceptSet = "";
+
+                if ($scope.consultation && $scope.consultation.observationForms) {
+                    _.each($scope.consultation.observationForms, function (observationForm) {
+                        if (isTemplateMatch(observationForm, templateId)) {
+                            clearTemplateState(observationForm);
+                        }
+                    });
+                }
+
+                if ($scope.consultation && ($scope.consultation.lastvisited === currentTemplate.id || $scope.consultation.lastvisited === currentTemplate.formUuid)) {
+                    $scope.consultation.lastvisited = null;
+                }
+
+                if ($scope.leftPanelConceptSet && $scope.leftPanelConceptSet.uuid === currentTemplate.uuid &&
+                    $scope.leftPanelConceptSet.formUuid === currentTemplate.formUuid) {
+                    $scope.leftPanelConceptSet = "";
+                }
+
                 messagingService.showMessage("info", $translate.instant("CLINICAL_TEMPLATE_REMOVED_SUCCESS_KEY", {label: label}));
+
+                var parentScope = $scope.$parent;
+                while (parentScope && !parentScope.allTemplates) {
+                    parentScope = parentScope.$parent;
+                }
+                if (parentScope && parentScope.allTemplates) {
+                    if (!isFormPinned) {
+                        _.remove(parentScope.allTemplates, function (template) {
+                            return isTemplateMatch(template, templateId);
+                        });
+                    } else {
+                        _.each(parentScope.allTemplates, function (template) {
+                            if (isTemplateMatch(template, templateId)) {
+                                clearTemplateState(template);
+                            }
+                        });
+                    }
+                }
             };
 
             $scope.openActiveForm = function (conceptSet) {

--- a/ui/app/common/concept-set/directives/conceptSetGroup.js
+++ b/ui/app/common/concept-set/directives/conceptSetGroup.js
@@ -9,8 +9,10 @@ angular.module('bahmni.common.conceptSet')
                   conceptSetUiConfigService, $timeout, clinicalAppConfigService, $stateParams, $translate, $state) {
             var conceptSetUIConfig = conceptSetUiConfigService.getConfig();
             var init = function () {
-                $scope.validationHandler = new Bahmni.ConceptSet.ConceptSetGroupPanelViewValidationHandler($scope.allTemplates, $scope.consultation);
-                contextChangeHandler.add($scope.validationHandler.validate);
+                if ($scope.consultation && $scope.allTemplates) {
+                    $scope.validationHandler = new Bahmni.ConceptSet.ConceptSetGroupPanelViewValidationHandler($scope.allTemplates, $scope.consultation);
+                    contextChangeHandler.add($scope.validationHandler.validate);
+                }
             };
             $scope.toggleSideBar = function () {
                 $rootScope.showLeftpanelToggle = !$rootScope.showLeftpanelToggle;
@@ -114,6 +116,7 @@ angular.module('bahmni.common.conceptSet')
             };
 
             var clearTemplateState = function (template) {
+                if (!template) return;
                 template.observations = [];
                 template.hasUnsavedFormObservations = false;
                 template.draftValidationPassed = undefined;
@@ -161,6 +164,7 @@ angular.module('bahmni.common.conceptSet')
 
                 if ($scope.consultation && $scope.consultation.observations) {
                     $scope.consultation.observations = _.filter($scope.consultation.observations, function (observation) {
+                        if (!observation) return true;
                         if (observation.concept && observation.concept.uuid === templateId) {
                             return false;
                         }

--- a/ui/app/common/concept-set/directives/conceptSetGroup.js
+++ b/ui/app/common/concept-set/directives/conceptSetGroup.js
@@ -124,6 +124,7 @@ angular.module('bahmni.common.conceptSet')
                 template.component = null;
                 template.errorMessage = null;
                 template.isValid = undefined;
+                template.isAdded = false;
                 template.isOpen = false;
                 template.klass = "";
                 template.isLoaded = false;
@@ -145,16 +146,14 @@ angular.module('bahmni.common.conceptSet')
                 clearTemplateState(currentTemplate);
 
                 if (!isFormPinned) {
-                    if (!$rootScope.deletedFormIds) {
-                        $rootScope.deletedFormIds = [];
+                    if ($scope.consultation) {
+                        if (!$scope.consultation.deletedFormIds) {
+                            $scope.consultation.deletedFormIds = [];
+                        }
+                        if (!_.includes($scope.consultation.deletedFormIds, templateId)) {
+                            $scope.consultation.deletedFormIds.push(templateId);
+                        }
                     }
-                    if (!_.includes($rootScope.deletedFormIds, templateId)) {
-                        $rootScope.deletedFormIds.push(templateId);
-                    }
-
-                    _.remove($scope.allTemplates, function (template) {
-                        return isTemplateMatch(template, templateId);
-                    });
                     if ($scope.consultation && $scope.consultation.selectedObsTemplate) {
                         _.remove($scope.consultation.selectedObsTemplate, function (template) {
                             return isTemplateMatch(template, templateId);

--- a/ui/app/common/concept-set/models/conceptSetGroupPanelViewValidationHandler.js
+++ b/ui/app/common/concept-set/models/conceptSetGroupPanelViewValidationHandler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-Bahmni.ConceptSet.ConceptSetGroupPanelViewValidationHandler = function (conceptSetSections) {
+Bahmni.ConceptSet.ConceptSetGroupPanelViewValidationHandler = function (conceptSetSections, consultation) {
     this.add = function (validation) {
         var conceptSetPanel = getActiveConceptSet();
         if (conceptSetPanel.length == 1) {
@@ -14,11 +14,25 @@ Bahmni.ConceptSet.ConceptSetGroupPanelViewValidationHandler = function (conceptS
         });
     };
 
+    var isFormSelected = function (conceptSet) {
+        var selectedObsTemplate = consultation && consultation.selectedObsTemplate ? consultation.selectedObsTemplate : [];
+        if (!selectedObsTemplate || selectedObsTemplate.length === 0) {
+            return true;
+        }
+        return _.find(selectedObsTemplate, function (template) {
+            return template === conceptSet || template.uuid === conceptSet.uuid || template.id === conceptSet.id;
+        });
+    };
+
     this.validate = function () {
         var errorMessage = "";
         var allConceptSetSectionsValid = true;
 
         _.forEach(conceptSetSections, function (conceptSet) {
+            if (!isFormSelected(conceptSet)) {
+                return;
+            }
+
             if (conceptSet.validate && typeof conceptSet.validate == 'function') {
                 var validationReturn = conceptSet.validate();
                 conceptSet.isValid = validationReturn["allow"];

--- a/ui/test/unit/common/auth/logOutDirective.spec.js
+++ b/ui/test/unit/common/auth/logOutDirective.spec.js
@@ -131,6 +131,19 @@ describe("logOut directive", function () {
         }, 0);
     });
 
+    it("should logout directly when the app descriptor is not yet available (defaults to disabled)", function (done) {
+        $rootScope.formDraftFeatureEnabled = false;
+
+        element.triggerHandler('click');
+
+        setTimeout(function () {
+            expect(formDraftService.hasDraftsForProvider).not.toHaveBeenCalled();
+            expect(ngDialog.open).not.toHaveBeenCalled();
+            expect(sessionService.destroy).toHaveBeenCalled();
+            done();
+        }, 0);
+    });
+
     it("should logout without blocking when the drafts check fails", function (done) {
         formDraftService.hasDraftsForProvider.and.returnValue({
             then: function (success, failure) {

--- a/ui/test/unit/common/concept-set/directives/conceptSetGroup.spec.js
+++ b/ui/test/unit/common/concept-set/directives/conceptSetGroup.spec.js
@@ -63,20 +63,24 @@ describe("conceptSetGroup", function () {
                 {
                     "uuid": "conceptSet1",
                     "label": "Followup1",
+                    "alwaysShow": true,
                     clone: function () {
                         return {
                             "uuid": "conceptSet1",
-                            "label": "Followup1"
+                            "label": "Followup1",
+                            "alwaysShow": true
                         }
                     }
                 },
                 {
                     "uuid" : "conceptSet2",
                     "label": "Followup",
+                    "alwaysShow": true,
                     clone: function () {
                         return {
                             "uuid": "conceptSet2",
-                            "label": "Followup"
+                            "label": "Followup",
+                            "alwaysShow": true
                         }
                     }
                 },
@@ -84,11 +88,13 @@ describe("conceptSetGroup", function () {
                     "uuid" : "conceptSet3",
                     "klass": "active",
                     "label": "Followup",
+                    "alwaysShow": true,
                     clone: function () {
                         return {
                             "uuid": "conceptSet3",
                             "klass": "active",
-                            "label": "Followup"
+                            "label": "Followup",
+                            "alwaysShow": true
                         }
                     },
                     "observations": [{uuid : "uuid"}]
@@ -239,9 +245,9 @@ describe("conceptSetGroup", function () {
         compiledElementScope.remove(0);
         expect(compiledElementScope.allTemplates.length).toEqual(3);
         compiledElementScope.remove(2);
-        expect(compiledElementScope.allTemplates.length).toEqual(2);
+        expect(compiledElementScope.allTemplates.length).toEqual(3);
         compiledElementScope.remove(1);
-        expect(compiledElementScope.allTemplates.length).toEqual(2);
+        expect(compiledElementScope.allTemplates.length).toEqual(3);
     });
 
     it("canRemove should return true only if it is unsaved template", function(){
@@ -278,8 +284,32 @@ describe("conceptSetGroup", function () {
         expect(compiledElementScope.leftPanelConceptSet.name).toEqual("template");
         expect(compiledElementScope.allTemplates[1].label).toEqual("Followup");
         compiledElementScope.remove(1);
+        expect(compiledElementScope.allTemplates.length).toEqual(3);
+        expect(compiledElementScope.allTemplates[1].observations).toEqual([]);
+    });
+
+    it("should remove unpinned form from list immediately", function () {
+        var compiledElementScope = executeDirective();
+        compiledElementScope.allTemplates[1].alwaysShow = false;
+        compiledElementScope.consultation.selectedObsTemplate[1].alwaysShow = false;
+        scope.$digest();
+
+        expect(compiledElementScope.allTemplates.length).toEqual(3);
+        compiledElementScope.remove(1);
         expect(compiledElementScope.allTemplates.length).toEqual(2);
-        expect(compiledElementScope.allTemplates[1].label).toEqual("Followup");
         expect(compiledElementScope.allTemplates[0].label).toEqual("Followup1");
+        expect(compiledElementScope.allTemplates[1].label).toEqual("Followup");
+    });
+
+    it("should keep pinned form in list but clear observations when deleted", function () {
+        var compiledElementScope = executeDirective();
+        scope.$digest();
+
+        expect(compiledElementScope.allTemplates.length).toEqual(3);
+        expect(compiledElementScope.allTemplates[1].alwaysShow).toEqual(true);
+        compiledElementScope.remove(1);
+        expect(compiledElementScope.allTemplates.length).toEqual(3);
+        expect(compiledElementScope.allTemplates[1].observations).toEqual([]);
+        expect(compiledElementScope.allTemplates[1].isOpen).toEqual(false);
     });
 });

--- a/ui/test/unit/home/loginInitialization.spec.js
+++ b/ui/test/unit/home/loginInitialization.spec.js
@@ -39,6 +39,7 @@ describe('loginInitialization', function () {
         );
 
         $httpBackend.whenGET('../i18n/home/locale_en.json').respond({});
+        $httpBackend.whenGET('../i18n/common/locale_en.json').respond({});
         $httpBackend.whenGET('/bahmni_config/openmrs/i18n/home/locale_en.json').respond({});
     }));
 


### PR DESCRIPTION
# Summarry

Implement proper form deletion handling to distinguish between pinned and unpinned forms, preventing phantom validation and unwanted reappearance of deleted forms.

Refactored form deletion logic to:

1. Track deleted forms in $rootScope.deletedFormIds to prevent re-addition
2. Distinguish between pinned (alwaysShow=true) and unpinned forms:
   - Pinned forms: Keep in list with cleared data
   - Unpinned forms: Remove from list immediately
3. Clear all form state: observations, validations, components, form data
4. Filter observations to prevent deleted form data from being saved
5. Update validation handler to dynamically check current selectedObsTemplate

**conceptSetGroupPanelViewValidationHandler.js**
- Pass consultation parameter to constructor for dynamic form selection checks

**conceptSetGroup.js** (directive remove() function)
- Extract templateId calculation for consistent identification
- Create clearTemplateState() helper to properly reset form state
- Handle pinned vs unpinned forms based on alwaysShow property
- Track deleted forms in hiveDeletedFormIds
- Clear observations, formData, validation state, and component
- Update parent controller's allTemplates via scope chain walking

**conceptSetPageController.js**
- Add consultation parameter to validation handler initialization
- Filter deleted forms from selectedObsTemplate on reinitialize
- Check deletedFormIds before re-adding forms via insertTemplate/insertInDefaultOrder
- Filter observations from deleted forms before collection
- Filter extraObservations to exclude deleted form observations
- Prevent re-adding deleted forms from observations or URL parameters

hive card link:  https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=CX7MipL9Nw3Frjexj