### PR TITLE
Hive-124050 & Hive- 125725 | Nandini | Fix saved VDP order edit failing when adjacent same-drug order exists

### DIFF
--- a/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.jsx
+++ b/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.jsx
@@ -208,8 +208,15 @@ export function VariableDoseProtocolModalInner({ hostData, hostApi }) {
 
     const startDateForSubmission = (pickedDate) => {
         if (!pickedDate) return pickedDate;
-        const now = new Date();
+        const initial = initialValues.startDate ? new Date(initialValues.startDate) : null;
+        if (initial &&
+            initial.getFullYear() === pickedDate.getFullYear() &&
+            initial.getMonth() === pickedDate.getMonth() &&
+            initial.getDate() === pickedDate.getDate()) {
+            return initial;
+        }
         const combined = new Date(pickedDate);
+        const now = new Date();
         combined.setHours(now.getHours(), now.getMinutes(), now.getSeconds(), now.getMilliseconds());
         return combined;
     };

--- a/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.jsx
+++ b/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.jsx
@@ -208,9 +208,6 @@ export function VariableDoseProtocolModalInner({ hostData, hostApi }) {
 
     const startDateForSubmission = (pickedDate) => {
         if (!pickedDate) return pickedDate;
-        // initialValues.startDate is always a Date (drugOrder.effectiveStartDate) from the
-        // Angular host. A date-only string would parse as UTC midnight and break the
-        // local-timezone day comparison below, so guard against unparseable values.
         const initial = initialValues.startDate ? new Date(initialValues.startDate) : null;
         const initialIsValid = initial && Number.isFinite(initial.getTime());
         if (initialIsValid &&

--- a/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.jsx
+++ b/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.jsx
@@ -208,8 +208,12 @@ export function VariableDoseProtocolModalInner({ hostData, hostApi }) {
 
     const startDateForSubmission = (pickedDate) => {
         if (!pickedDate) return pickedDate;
+        // initialValues.startDate is always a Date (drugOrder.effectiveStartDate) from the
+        // Angular host. A date-only string would parse as UTC midnight and break the
+        // local-timezone day comparison below, so guard against unparseable values.
         const initial = initialValues.startDate ? new Date(initialValues.startDate) : null;
-        if (initial &&
+        const initialIsValid = initial && Number.isFinite(initial.getTime());
+        if (initialIsValid &&
             initial.getFullYear() === pickedDate.getFullYear() &&
             initial.getMonth() === pickedDate.getMonth() &&
             initial.getDate() === pickedDate.getDate()) {

--- a/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.spec.jsx
+++ b/micro-frontends/src/next-ui/Components/VariableDoseProtocol/VariableDoseProtocolModal.spec.jsx
@@ -642,6 +642,116 @@ describe("Edit Mode (initialValues pre-population)", () => {
     });
 });
 
+describe("Start date submission", () => {
+    const prePopulatedInitialValues = (startDate) => ({
+        drug: { name: "Paracetamol", uuid: "drug-uuid-1", dosageForm: { display: "Tablet" } },
+        units: "mg",
+        route: "Oral",
+        startDate,
+        isLoadingDose: false,
+        loadingDose: null,
+        stages: [validStage(), validStage()],
+    });
+
+    it("preserves the original time-of-day when saving a saved-order edit with a non-midnight start date", async () => {
+        const originalStartDate = new Date(2024, 0, 1, 10, 30, 0);
+        renderModal({
+            ...defaultHostData,
+            editMode: true,
+            initialValues: prePopulatedInitialValues(originalStartDate),
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("Save Changes").closest("button").disabled).toBe(false);
+        });
+        fireEvent.click(screen.getByText("Save Changes").closest("button"));
+
+        const sentStartDate = mockOnSave.mock.calls[0][0].startDate;
+        expect(sentStartDate.getFullYear()).toBe(2024);
+        expect(sentStartDate.getMonth()).toBe(0);
+        expect(sentStartDate.getDate()).toBe(1);
+        expect(sentStartDate.getHours()).toBe(10);
+        expect(sentStartDate.getMinutes()).toBe(30);
+    });
+
+    it("preserves an untouched midnight start date exactly on a saved-order edit (no re-stamping)", async () => {
+        const originalStartDate = new Date(2024, 0, 1);
+        renderModal({
+            ...defaultHostData,
+            editMode: true,
+            initialValues: prePopulatedInitialValues(originalStartDate),
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("Save Changes").closest("button").disabled).toBe(false);
+        });
+        fireEvent.click(screen.getByText("Save Changes").closest("button"));
+
+        const sentStartDate = mockOnSave.mock.calls[0][0].startDate;
+        expect(sentStartDate.getFullYear()).toBe(2024);
+        expect(sentStartDate.getMonth()).toBe(0);
+        expect(sentStartDate.getDate()).toBe(1);
+        expect(sentStartDate.getHours()).toBe(0);
+        expect(sentStartDate.getMinutes()).toBe(0);
+    });
+
+    it("stamps the current time-of-day only when the user actually changes the start date on a saved-order edit", async () => {
+        const originalStartDate = new Date(2024, 0, 1, 10, 30, 0);
+        const { container } = renderModal({
+            ...defaultHostData,
+            editMode: true,
+            initialValues: prePopulatedInitialValues(originalStartDate),
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("Save Changes").closest("button").disabled).toBe(false);
+        });
+
+        const dateInput = getDropdownInput(container, "variable-dose-start-date");
+        fireEvent.change(dateInput, { target: { value: "10 Feb 2024" } });
+        fireEvent.blur(dateInput);
+
+        fireEvent.click(screen.getByText("Save Changes").closest("button"));
+
+        const sentStartDate = mockOnSave.mock.calls[0][0].startDate;
+        expect(sentStartDate.getFullYear()).toBe(2024);
+        expect(sentStartDate.getMonth()).toBe(1);
+        expect(sentStartDate.getDate()).toBe(10);
+        const sentElapsed = sentStartDate.getTime() - new Date(2024, 1, 10).getTime();
+        const now = new Date();
+        const nowElapsed = now.getTime() - new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+        expect(sentElapsed).toBeGreaterThanOrEqual(nowElapsed - 60000);
+        expect(sentElapsed).toBeLessThanOrEqual(nowElapsed);
+    });
+
+    it("stamps the current time-of-day when a new order's start date is picked (no previous date exists)", async () => {
+        const { container } = renderModal({
+            ...defaultHostData,
+            initialValues: prePopulatedInitialValues(null),
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("Save").closest("button").disabled).toBe(false);
+        });
+
+        const dateInput = getDropdownInput(container, "variable-dose-start-date");
+        fireEvent.change(dateInput, { target: { value: "10 Feb 2024" } });
+        fireEvent.blur(dateInput);
+
+        fireEvent.click(screen.getByText("Save").closest("button"));
+
+        const sentStartDate = mockOnSave.mock.calls[0][0].startDate;
+        expect(sentStartDate.getFullYear()).toBe(2024);
+        expect(sentStartDate.getMonth()).toBe(1);
+        expect(sentStartDate.getDate()).toBe(10);
+        const sentElapsed = sentStartDate.getTime() - new Date(2024, 1, 10).getTime();
+        const now = new Date();
+        const nowElapsed = now.getTime() - new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+        expect(sentElapsed).toBeGreaterThanOrEqual(nowElapsed - 60000);
+        expect(sentElapsed).toBeLessThanOrEqual(nowElapsed);
+    });
+});
+
 describe("Non-coded drug (Accept flow)", () => {
     it("Accept checkbox is enabled when text is typed and no coded drug is selected", async () => {
         const { container } = renderModal();

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -13,6 +13,10 @@ angular.module('bahmni.clinical')
             var DateUtil = Bahmni.Common.Util.DateUtil;
             var DrugOrderViewModel = Bahmni.Clinical.DrugOrderViewModel;
             var scrollTop = _.partial($window.scrollTo, 0, 0);
+            // Captured in init() from $scope.consultation.activeAndScheduledDrugOrders so the conflict
+            // check survives copyConsultationToScope replacing $scope.consultation. treatmentDrugs is
+            // the primary post-save source (see getConflictingDrugOrder); this snapshot is the last
+            // resort when neither pool exists. Do not remove the fallback chain below.
             var activeAndScheduledOrdersSnapshot = [];
 
             $scope.showOrderSetDetails = true;
@@ -512,6 +516,8 @@ angular.module('bahmni.clinical')
                 allDrugOrders = _.reject(allDrugOrders, newDrugOrder);
                 var unsavedNotBeingEditedOrders = _.filter(allDrugOrders, { isBeingEdited: false });
                 var existingDrugOrders;
+                // Post-save consultations carry treatmentDrugs (consultationMapper); the init() snapshot
+                // covers cases where neither pool exists. Keep this chain intact.
                 var existingActiveOrders = $scope.consultation.activeAndScheduledDrugOrders ||
                     $scope.consultation.treatmentDrugs ||
                     activeAndScheduledOrdersSnapshot;
@@ -1143,6 +1149,8 @@ angular.module('bahmni.clinical')
 
                     var findConflictingVdpOrder = function (data) {
                         var newDrugOrder = buildPendingVdpDrugOrder(data);
+                        // revisingVariableDoseDrugOrder is set by event:reviseVariableDoseOrder;
+                        // editedOrder may be undefined if the broadcast was missed, hence the guard.
                         var editedOrder = (editingVariableDoseIndex >= 0)
                             ? ($scope.consultation.variableDoseTreatments || [])[editingVariableDoseIndex]
                             : revisingVariableDoseDrugOrder;

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -13,6 +13,7 @@ angular.module('bahmni.clinical')
             var DateUtil = Bahmni.Common.Util.DateUtil;
             var DrugOrderViewModel = Bahmni.Clinical.DrugOrderViewModel;
             var scrollTop = _.partial($window.scrollTo, 0, 0);
+            var activeAndScheduledOrdersSnapshot = [];
 
             $scope.showOrderSetDetails = true;
             $scope.addTreatment = true;
@@ -511,10 +512,13 @@ angular.module('bahmni.clinical')
                 allDrugOrders = _.reject(allDrugOrders, newDrugOrder);
                 var unsavedNotBeingEditedOrders = _.filter(allDrugOrders, { isBeingEdited: false });
                 var existingDrugOrders;
+                var existingActiveOrders = $scope.consultation.activeAndScheduledDrugOrders ||
+                    $scope.consultation.treatmentDrugs ||
+                    activeAndScheduledOrdersSnapshot;
                 if (newDrugOrder.isBeingEdited) {
-                    existingDrugOrders = _.reject($scope.consultation.activeAndScheduledDrugOrders, { uuid: newDrugOrder.previousOrderUuid });
+                    existingDrugOrders = _.reject(existingActiveOrders, { uuid: newDrugOrder.previousOrderUuid });
                 } else {
-                    existingDrugOrders = $scope.consultation.activeAndScheduledDrugOrders;
+                    existingDrugOrders = existingActiveOrders;
                 }
                 existingDrugOrders = existingDrugOrders.concat(unsavedNotBeingEditedOrders);
 
@@ -1001,6 +1005,7 @@ angular.module('bahmni.clinical')
                 $scope.consultation.discontinuedDrugs = $scope.consultation.discontinuedDrugs || [];
                 $scope.consultation.drugOrdersWithUpdatedOrderAttributes = $scope.consultation.drugOrdersWithUpdatedOrderAttributes || {};
                 $scope.consultation.activeAndScheduledDrugOrders = getActiveDrugOrders(activeDrugOrders);
+                activeAndScheduledOrdersSnapshot = $scope.consultation.activeAndScheduledDrugOrders;
 
                 mergeActiveAndScheduledWithDiscontinuedOrders();
 
@@ -1138,6 +1143,13 @@ angular.module('bahmni.clinical')
 
                     var findConflictingVdpOrder = function (data) {
                         var newDrugOrder = buildPendingVdpDrugOrder(data);
+                        var editedOrder = (editingVariableDoseIndex >= 0)
+                            ? ($scope.consultation.variableDoseTreatments || [])[editingVariableDoseIndex]
+                            : revisingVariableDoseDrugOrder;
+                        if (editedOrder && editedOrder.uuid) {
+                            newDrugOrder.isBeingEdited = true;
+                            newDrugOrder.previousOrderUuid = editedOrder.uuid;
+                        }
                         var vdpExcludeIndex = editingVariableDoseIndex >= 0 ? editingVariableDoseIndex : undefined;
                         var conflict = getConflictingDrugOrder(newDrugOrder, vdpExcludeIndex);
                         return conflict || null;

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -13,10 +13,6 @@ angular.module('bahmni.clinical')
             var DateUtil = Bahmni.Common.Util.DateUtil;
             var DrugOrderViewModel = Bahmni.Clinical.DrugOrderViewModel;
             var scrollTop = _.partial($window.scrollTo, 0, 0);
-            // Captured in init() from $scope.consultation.activeAndScheduledDrugOrders so the conflict
-            // check survives copyConsultationToScope replacing $scope.consultation. treatmentDrugs is
-            // the primary post-save source (see getConflictingDrugOrder); this snapshot is the last
-            // resort when neither pool exists. Do not remove the fallback chain below.
             var activeAndScheduledOrdersSnapshot = [];
 
             $scope.showOrderSetDetails = true;
@@ -516,8 +512,6 @@ angular.module('bahmni.clinical')
                 allDrugOrders = _.reject(allDrugOrders, newDrugOrder);
                 var unsavedNotBeingEditedOrders = _.filter(allDrugOrders, { isBeingEdited: false });
                 var existingDrugOrders;
-                // Post-save consultations carry treatmentDrugs (consultationMapper); the init() snapshot
-                // covers cases where neither pool exists. Keep this chain intact.
                 var existingActiveOrders = $scope.consultation.activeAndScheduledDrugOrders ||
                     $scope.consultation.treatmentDrugs ||
                     activeAndScheduledOrdersSnapshot;
@@ -1149,8 +1143,6 @@ angular.module('bahmni.clinical')
 
                     var findConflictingVdpOrder = function (data) {
                         var newDrugOrder = buildPendingVdpDrugOrder(data);
-                        // revisingVariableDoseDrugOrder is set by event:reviseVariableDoseOrder;
-                        // editedOrder may be undefined if the broadcast was missed, hence the guard.
                         var editedOrder = (editingVariableDoseIndex >= 0)
                             ? ($scope.consultation.variableDoseTreatments || [])[editingVariableDoseIndex]
                             : revisingVariableDoseDrugOrder;

--- a/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
+++ b/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
@@ -2668,5 +2668,195 @@ describe("AddTreatmentController", function () {
             expect(entry.concept).toBeNull();
             expect(entry.drugName).toBe('Prednisolone');
         });
+
+        describe("VDP duplicate validation on create and edit", function () {
+            beforeEach(function () {
+                scope.variableDoseHostApi.openModal = jasmine.createSpy('openModal');
+            });
+
+            var makeStage = function (startDate) {
+                return { stageName: 'Stage 1', sequence: 1, isLoadingDose: false, dose: '5', unit: 'mg', frequency: 'Twice a day', frequencyPerDay: 2, duration: '1', durationUnit: 'Day(s)', instructions: '', rate: '', additives: '', additionalInstructions: '', startDate: startDate || new Date('2026-08-08') };
+            };
+
+            var buildSaveData = function (overrides) {
+                return angular.extend({
+                    drug: { uuid: 'drug-uuid', name: 'Prednisolone', dosageForm: { display: 'Tablet' } },
+                    isNonCodedDrug: false,
+                    drugNonCoded: null,
+                    units: 'mg',
+                    route: 'Oral',
+                    startDate: new Date('2026-08-08'),
+                    dosingRule: '',
+                    loadingDose: null,
+                    stages: [makeStage()]
+                }, overrides || {});
+            };
+
+            var savedOrderFor = function (overrides) {
+                var order = Bahmni.Tests.drugOrderViewModelMother.buildWith({}, angular.extend({
+                    drug: { name: 'Prednisolone', uuid: 'drug-uuid' },
+                    uuid: 'order-uuid',
+                    effectiveStartDate: DateUtil.parse('2026-08-08'),
+                    effectiveStopDate: DateUtil.parse('2026-08-09')
+                }, overrides || {}));
+                order.careSetting = Bahmni.Clinical.Constants.careSetting.outPatient;
+                return order;
+            };
+
+            it("should allow revising a saved VDP order when a future prescription for the same drug exists (regression: must not conflict with itself)", function () {
+                scope.consultation.activeAndScheduledDrugOrders = [
+                    savedOrderFor({ uuid: 'aug-8-order', effectiveStartDate: DateUtil.parse('2026-08-08'), effectiveStopDate: DateUtil.parse('2026-08-09') }),
+                    savedOrderFor({ uuid: 'aug-10-order', effectiveStartDate: DateUtil.parse('2026-08-10'), effectiveStopDate: DateUtil.parse('2026-08-11') })
+                ];
+
+                rootScope.$broadcast('event:reviseVariableDoseOrder', scope.consultation.activeAndScheduledDrugOrders[0]);
+                scope.variableDoseHostApi.onSave(buildSaveData(), true);
+                $timeout.flush();
+                rootScope.$apply();
+
+                expect(ngDialog.open).not.toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(1);
+                expect(scope.consultation.variableDoseTreatments[0].action).toBe(Bahmni.Clinical.Constants.orderActions.revise);
+                expect(scope.consultation.variableDoseTreatments[0].previousOrderUuid).toBe('aug-8-order');
+            });
+
+            it("should allow revising a saved VDP order when no other prescription exists", function () {
+                scope.consultation.activeAndScheduledDrugOrders = [
+                    savedOrderFor({ uuid: 'aug-8-order', effectiveStartDate: DateUtil.parse('2026-08-08'), effectiveStopDate: DateUtil.parse('2026-08-09') })
+                ];
+
+                rootScope.$broadcast('event:reviseVariableDoseOrder', scope.consultation.activeAndScheduledDrugOrders[0]);
+                scope.variableDoseHostApi.onSave(buildSaveData(), true);
+                $timeout.flush();
+                rootScope.$apply();
+
+                expect(ngDialog.open).not.toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(1);
+                expect(scope.consultation.variableDoseTreatments[0].action).toBe(Bahmni.Clinical.Constants.orderActions.revise);
+            });
+
+            it("should allow creating two non-overlapping VDPs for the same drug", function () {
+                scope.variableDoseHostApi.onSave(buildSaveData(), false);
+                $timeout.flush();
+                rootScope.$apply();
+
+                scope.variableDoseHostApi.onSave(buildSaveData({
+                    startDate: new Date('2026-08-20'),
+                    stages: [makeStage(new Date('2026-08-20'))]
+                }), false);
+                $timeout.flush();
+                rootScope.$apply();
+
+                expect(ngDialog.open).not.toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(2);
+            });
+
+            it("should block creating a second overlapping VDP for the same drug", function () {
+                scope.variableDoseHostApi.onSave(buildSaveData(), false);
+                $timeout.flush();
+                rootScope.$apply();
+
+                scope.variableDoseHostApi.onSave(buildSaveData({
+                    startDate: new Date('2026-08-09'),
+                    stages: [makeStage(new Date('2026-08-09'))]
+                }), false);
+                rootScope.$apply();
+
+                expect(ngDialog.open).toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(1);
+            });
+
+            it("should allow editing an unsaved coded VDP without conflicting with itself", function () {
+                scope.variableDoseHostApi.onSave(buildSaveData(), false);
+                $timeout.flush();
+                rootScope.$apply();
+
+                rootScope.$broadcast('event:editVariableDoseOrder', 0);
+                scope.variableDoseHostApi.onSave(buildSaveData({
+                    startDate: new Date('2026-08-10'),
+                    stages: [makeStage(new Date('2026-08-10'))]
+                }), false);
+                $timeout.flush();
+                rootScope.$apply();
+
+                expect(ngDialog.open).not.toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(1);
+                expect(scope.consultation.variableDoseTreatments[0].startDate.getTime()).toBe(new Date('2026-08-10').getTime());
+            });
+
+            it("should allow editing an unsaved non-coded VDP without conflicting with itself", function () {
+                scope.variableDoseHostApi.onSave(buildSaveData({
+                    drug: null,
+                    isNonCodedDrug: true,
+                    drugNonCoded: 'Herbal Mixture 500mg'
+                }), false);
+                $timeout.flush();
+                rootScope.$apply();
+
+                rootScope.$broadcast('event:editVariableDoseOrder', 0);
+                scope.variableDoseHostApi.onSave(buildSaveData({
+                    drug: null,
+                    isNonCodedDrug: true,
+                    drugNonCoded: 'Herbal Mixture 500mg',
+                    startDate: new Date('2026-08-10'),
+                    stages: [makeStage(new Date('2026-08-10'))]
+                }), false);
+                $timeout.flush();
+                rootScope.$apply();
+
+                expect(ngDialog.open).not.toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(1);
+                expect(scope.consultation.variableDoseTreatments[0].drugNonCoded).toBe('Herbal Mixture 500mg');
+            });
+
+            it("should still block a new VDP that duplicates an active regular prescription", function () {
+                scope.consultation.activeAndScheduledDrugOrders = [
+                    savedOrderFor({ uuid: 'active-regular-order', effectiveStartDate: DateUtil.parse('2026-08-08'), effectiveStopDate: DateUtil.parse('2026-08-12') })
+                ];
+
+                scope.variableDoseHostApi.onSave(buildSaveData(), false);
+                rootScope.$apply();
+
+                expect(ngDialog.open).toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(0);
+            });
+
+            it("should still allow revising a saved VDP order when activeAndScheduledDrugOrders is missing but treatmentDrugs is present (post-save consultation)", function () {
+                scope.consultation.activeAndScheduledDrugOrders = undefined;
+                scope.consultation.treatmentDrugs = [
+                    savedOrderFor({ uuid: 'aug-8-order', effectiveStartDate: DateUtil.parse('2026-08-08'), effectiveStopDate: DateUtil.parse('2026-08-09') }),
+                    savedOrderFor({ uuid: 'aug-10-order', effectiveStartDate: DateUtil.parse('2026-08-10'), effectiveStopDate: DateUtil.parse('2026-08-11') })
+                ];
+
+                rootScope.$broadcast('event:reviseVariableDoseOrder', scope.consultation.treatmentDrugs[0]);
+                scope.variableDoseHostApi.onSave(buildSaveData(), true);
+                $timeout.flush();
+                rootScope.$apply();
+
+                expect(ngDialog.open).not.toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(1);
+                expect(scope.consultation.variableDoseTreatments[0].action).toBe(Bahmni.Clinical.Constants.orderActions.revise);
+                expect(scope.consultation.variableDoseTreatments[0].previousOrderUuid).toBe('aug-8-order');
+            });
+
+            it("should still block an overlapping revise when activeAndScheduledDrugOrders is missing but treatmentDrugs is present (post-save consultation)", function () {
+                scope.consultation.activeAndScheduledDrugOrders = undefined;
+                scope.consultation.treatmentDrugs = [
+                    savedOrderFor({ uuid: 'aug-8-order', effectiveStartDate: DateUtil.parse('2026-08-08'), effectiveStopDate: DateUtil.parse('2026-08-09') }),
+                    savedOrderFor({ uuid: 'aug-9-order', effectiveStartDate: DateUtil.parse('2026-08-09'), effectiveStopDate: DateUtil.parse('2026-08-11') })
+                ];
+
+                rootScope.$broadcast('event:reviseVariableDoseOrder', scope.consultation.treatmentDrugs[0]);
+                scope.variableDoseHostApi.onSave(buildSaveData({
+                    stages: [{
+                        stageName: 'Stage 1', sequence: 1, isLoadingDose: false, dose: '5', unit: 'mg', frequency: 'Twice a day', frequencyPerDay: 2, duration: '2', durationUnit: 'Day(s)', instructions: '', rate: '', additives: '', additionalInstructions: '', startDate: new Date('2026-08-08')
+                    }]
+                }), true);
+                rootScope.$apply();
+
+                expect(ngDialog.open).toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(0);
+            });
+        });
     });
 });

--- a/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
+++ b/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
@@ -2857,6 +2857,23 @@ describe("AddTreatmentController", function () {
                 expect(ngDialog.open).toHaveBeenCalled();
                 expect(scope.consultation.variableDoseTreatments.length).toBe(0);
             });
+
+            it("should allow revising a saved VDP order when both activeAndScheduledDrugOrders and treatmentDrugs are missing (init snapshot fallback)", function () {
+                scope.consultation.activeAndScheduledDrugOrders = undefined;
+                scope.consultation.treatmentDrugs = undefined;
+
+                rootScope.$broadcast('event:reviseVariableDoseOrder', savedOrderFor({
+                    uuid: 'aug-8-order', effectiveStartDate: DateUtil.parse('2026-08-08'), effectiveStopDate: DateUtil.parse('2026-08-09')
+                }));
+                scope.variableDoseHostApi.onSave(buildSaveData(), true);
+                $timeout.flush();
+                rootScope.$apply();
+
+                expect(ngDialog.open).not.toHaveBeenCalled();
+                expect(scope.consultation.variableDoseTreatments.length).toBe(1);
+                expect(scope.consultation.variableDoseTreatments[0].action).toBe(Bahmni.Clinical.Constants.orderActions.revise);
+                expect(scope.consultation.variableDoseTreatments[0].previousOrderUuid).toBe('aug-8-order');
+            });
         });
     });
 });


### PR DESCRIPTION

## Description

### Problem
Editing a **saved** VDP (Variable Dosage Protocol) order and saving the consultation fails when a second same-drug VDP order starts on an **adjacent day** (e.g. orders on Aug 8 and Aug 9, ~1-day durations). The failure happens at the **main consultation Save** — the server rejects the REVISE with:

> "One or more drugs you are trying to order are already active."

(plus a 404). Reproduces for both coded and non-coded drugs.

A related symptom is also fixed: **editing a non-coded VDP medication triggered the "duplicate medication" block** — the edited order conflicted with *itself* during the modal's save-time conflict check.

### Root Cause
Two independent issues combined:

1. **Start date re-stamped on every edit.** `startDateForSubmission` in the React VDP modal unconditionally overwrote the picked date's time-of-day with the current clock time — even when the user never changed the date on a saved-order edit. Editing an Aug 8 order in the afternoon turned `Aug 8 09:30` into `Aug 8 14:30`, pushing the order's end (`start + N days`) past the Aug 9 order's start → real overlap → server rejects the REVISE.

2. **Frontend conflict check silently disabled after save.** `copyConsultationToScope` replaces the `consultation` object, losing `activeAndScheduledDrugOrders` (populated only on the old object), so `getConflictingDrugOrder` silently passed and the overlap reached the server instead of being blocked in the UI.

### Fix
- **`VariableDoseProtocolModal.jsx`** — `startDateForSubmission` now returns the original date-time **verbatim** when the start date is unchanged; it stamps the current time only for genuinely new picks (date changed, or new order). This mirrors the normal drug flow, where an unchanged edit keeps the previous date-time.
- **`addTreatmentController.js`** —
  - keeps an `activeAndScheduledOrdersSnapshot` (set in `init()`) and resolves the conflict-check pool via a fallback chain: `activeAndScheduledDrugOrders` → `treatmentDrugs` → snapshot;
  - `findConflictingVdpOrder` now marks the order being revised (`isBeingEdited` + `previousOrderUuid`) so it is **excluded from the conflict check and doesn't conflict with itself** — this fixes the non-coded "duplicate medication" block on edit.

### Testing
- **React**: 4 new specs ("Start date submission") — 303 tests passing.
- **Angular**: 9 new specs ("VDP duplicate validation on create and edit"), including non-coded self-edit — 2952 karma tests passing.
- Lint clean on all changed files.

### Behavior after fix
| Scenario | Result |
| --- | --- |
| Edit saved order, date untouched | Original date + time preserved (even if midnight) |
| Edit saved order, date changed | New day + current time-of-day |
| New order, date picked | New day + current time-of-day (adjacent-day behavior preserved) |
| Edit non-coded VDP | No false "duplicate medication" block |

Hive cards : 
https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=b3vTEPpimdu9rF93i
https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=j3zNB6dAYHhhNQJJ7
