### PR TITLE
Hive-126558|Karthik|prevent unsaved data popup appearing after main consultation save

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -857,15 +857,13 @@ angular.module('bahmni.clinical')
                                 return;
                             }
                             $scope.formDraft.isDirty = newTemplateState !== dirtyTrackingState.cleanState || newExtraState !== dirtyTrackingState.cleanStateExtras;
-                            if (!dirtyTrackingState.mainSaveInProgress) {
+                            if (!dirtyTrackingState.mainSaveInProgress && !$state.justSaved) {
                                 if ($scope.formDraft.isDirty) {
                                     $state.dirtyConsultationForm = true;
                                     $state.justSaved = false;
                                     startAutoSaveIfDirty();
                                 } else {
-                                    if (!$state.justSaved) {
-                                        $state.dirtyConsultationForm = false;
-                                    }
+                                    $state.dirtyConsultationForm = false;
                                 }
                             }
                             updateTemplateDirtyIndicators();

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -857,10 +857,12 @@ angular.module('bahmni.clinical')
                                 return;
                             }
                             $scope.formDraft.isDirty = newTemplateState !== dirtyTrackingState.cleanState || newExtraState !== dirtyTrackingState.cleanStateExtras;
+                            if ($scope.formDraft.isDirty && $state.justSaved) {
+                                $state.justSaved = false;
+                            }
                             if (!dirtyTrackingState.mainSaveInProgress && !$state.justSaved) {
                                 if ($scope.formDraft.isDirty) {
                                     $state.dirtyConsultationForm = true;
-                                    $state.justSaved = false;
                                     startAutoSaveIfDirty();
                                 } else {
                                     $state.dirtyConsultationForm = false;
@@ -991,14 +993,18 @@ angular.module('bahmni.clinical')
                 return $q.when();
             };
 
-            $rootScope.$on('event:save-started', function () {
+            var deregSaveStarted = $rootScope.$on('event:save-started', function () {
                 dirtyTrackingState.mainSaveInProgress = true;
             });
 
-            $rootScope.$on('event:changes-saved', function () {
+            var deregChangesSaved = $rootScope.$on('event:changes-saved', function () {
                 dirtyTrackingState.mainSaveInProgress = false;
                 dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                 $scope.formDraft.isDirty = false;
+            });
+
+            var deregSaveFailed = $rootScope.$on('event:save-failed', function () {
+                dirtyTrackingState.mainSaveInProgress = false;
             });
 
             var draftCheckPromise = null;
@@ -1173,6 +1179,9 @@ angular.module('bahmni.clinical')
                 }
                 saveSuccessfulListener();
                 saveStartedListener();
+                deregSaveStarted();
+                deregChangesSaved();
+                deregSaveFailed();
                 $state.saveFormDraftIfDirty = null;
             });
 

--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -670,7 +670,8 @@ angular.module('bahmni.clinical')
                 postSaveRefreshTimeout: null,
                 form2ListenerState: null,
                 isSaving: false,
-                extraObservations: []
+                extraObservations: [],
+                mainSaveInProgress: false
             };
 
             var savePersistentBaseline = function (cleanState) {
@@ -856,9 +857,16 @@ angular.module('bahmni.clinical')
                                 return;
                             }
                             $scope.formDraft.isDirty = newTemplateState !== dirtyTrackingState.cleanState || newExtraState !== dirtyTrackingState.cleanStateExtras;
-                            if ($scope.formDraft.isDirty) {
-                                $state.dirtyConsultationForm = true;
-                                startAutoSaveIfDirty();
+                            if (!dirtyTrackingState.mainSaveInProgress) {
+                                if ($scope.formDraft.isDirty) {
+                                    $state.dirtyConsultationForm = true;
+                                    $state.justSaved = false;
+                                    startAutoSaveIfDirty();
+                                } else {
+                                    if (!$state.justSaved) {
+                                        $state.dirtyConsultationForm = false;
+                                    }
+                                }
                             }
                             updateTemplateDirtyIndicators();
                         }
@@ -908,13 +916,6 @@ angular.module('bahmni.clinical')
                         );
                     }
 
-                    $scope.$evalAsync(function () {
-                        var currentState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
-                        if (currentState !== savedCleanState) {
-                            $scope.formDraft.isDirty = true;
-                        }
-                    });
-
                     var savedDate = new Date(serverTimestamp);
                     var draftDate = $filter('date')(savedDate, 'dd MMM yyyy');
                     var draftTime = $filter('date')(savedDate, 'hh:mm a');
@@ -924,7 +925,6 @@ angular.module('bahmni.clinical')
                     $scope.formDraft.statusParams = {draftDate: draftDate, draftTime: draftTime};
                     $scope.formDraft.draftDate = draftDate;
                     $scope.formDraft.draftTime = draftTime;
-                    $scope.formDraft.isDirty = false;
                     $scope.formDraft.hasDrafts = true;
                     dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
                     dirtyTrackingState.cleanStateExtras = angular.toJson(dirtyTrackingState.extraObservations);
@@ -932,6 +932,15 @@ angular.module('bahmni.clinical')
                     $scope.consultation._draftCleanState = dirtyTrackingState.cleanState;
                     savePersistentBaseline(dirtyTrackingState.cleanState);
                     dirtyTrackingState.postSaveRefreshPending = true;
+
+                    $scope.$evalAsync(function () {
+                        var currentState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                        if (currentState !== dirtyTrackingState.cleanState) {
+                            $scope.formDraft.isDirty = true;
+                        } else {
+                            $scope.formDraft.isDirty = false;
+                        }
+                    });
 
                     var savedCleanState = dirtyTrackingState.cleanState;
                     var savedCleanStateExtras = dirtyTrackingState.cleanStateExtras;
@@ -983,6 +992,16 @@ angular.module('bahmni.clinical')
                 }
                 return $q.when();
             };
+
+            $rootScope.$on('event:save-started', function () {
+                dirtyTrackingState.mainSaveInProgress = true;
+            });
+
+            $rootScope.$on('event:changes-saved', function () {
+                dirtyTrackingState.mainSaveInProgress = false;
+                dirtyTrackingState.cleanState = formDirtyStateService.getObsValues($scope.consultation.selectedObsTemplate);
+                $scope.formDraft.isDirty = false;
+            });
 
             var draftCheckPromise = null;
             var draftContextWatchDeregister = null;

--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -575,7 +575,6 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                     return $q.when({});
                 }
                 sessionStorage.setItem('formSaveCompleted', 'true');
-                $state.mainSaveInProgress = true;
                 $rootScope.$broadcast('event:save-started');
                 try {
                     var alerts = angular.copy($rootScope.cdssAlerts) || [];
@@ -585,6 +584,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
 
                     if (activeAlerts && activeAlerts.length > 0) {
                         messagingService.showMessage("error", "{{ 'CDSS_ALERT_SAVE_ERROR' | translate }}");
+                        $rootScope.$broadcast('event:save-failed');
                         return $q.when({});
                     }
 
@@ -606,7 +606,6 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                             params.cachebuster = Math.random();
                             return encounterService.create(encounterData)
                             .then(function (saveResponse) {
-                                $state.mainSaveInProgress = false;
                                 $state.dirtyConsultationForm = false;
                                 $state.orderRemoved = false;
                                 $state.orderCreated = false;
@@ -651,6 +650,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                                         });
                                     }));
                             }).catch(function (error) {
+                                $rootScope.$broadcast('event:save-failed');
                                 var message = Bahmni.Clinical.Error.translate(error) || "{{'CLINICAL_SAVE_FAILURE_MESSAGE_KEY' | translate}}";
                                 messagingService.showMessage('error', message);
                             });

--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -575,6 +575,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                     return $q.when({});
                 }
                 sessionStorage.setItem('formSaveCompleted', 'true');
+                $state.mainSaveInProgress = true;
                 $rootScope.$broadcast('event:save-started');
                 try {
                     var alerts = angular.copy($rootScope.cdssAlerts) || [];
@@ -605,10 +606,12 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                             params.cachebuster = Math.random();
                             return encounterService.create(encounterData)
                             .then(function (saveResponse) {
+                                $state.mainSaveInProgress = false;
                                 $state.dirtyConsultationForm = false;
                                 $state.orderRemoved = false;
                                 $state.orderCreated = false;
-                                $scope.$parent.$broadcast("event:changes-saved");
+                                $rootScope.$broadcast("event:changes-saved");
+                                $state.justSaved = true;
                                 var messageParams = {
                                     encounterUuid: saveResponse.data.encounterUuid,
                                     encounterType: saveResponse.data.encounterType

--- a/ui/app/clinical/consultation/directives/alertOnExit.js
+++ b/ui/app/clinical/consultation/directives/alertOnExit.js
@@ -5,10 +5,6 @@ angular.module('bahmni.clinical')
         function (exitAlertService, $state, $rootScope) {
             return {
                 link: function ($scope) {
-                    $rootScope.$on('event:save-successful', function () {
-                        $state.justSaved = true;
-                    });
-
                     $scope.$on('$stateChangeStart', function (event, next, current) {
                         var uuid = $state.params.patientUuid;
                         var currentUuid = current.patientUuid;
@@ -22,6 +18,7 @@ angular.module('bahmni.clinical')
                         } else {
                             $state.dirtyConsultationForm = $state.discardChanges ? false : $state.dirtyConsultationForm;
                         }
+
                         exitAlertService.showExitAlert(isNavigating, $state.dirtyConsultationForm, event, next.spinnerToken);
                     });
                 }

--- a/ui/app/clinical/consultation/directives/alertOnExit.js
+++ b/ui/app/clinical/consultation/directives/alertOnExit.js
@@ -1,15 +1,27 @@
 "use strict";
 
 angular.module('bahmni.clinical')
-    .directive('alertOnExit', ['exitAlertService', '$state',
-        function (exitAlertService, $state) {
+    .directive('alertOnExit', ['exitAlertService', '$state', '$rootScope',
+        function (exitAlertService, $state, $rootScope) {
             return {
                 link: function ($scope) {
+                    $rootScope.$on('event:save-successful', function () {
+                        $state.justSaved = true;
+                    });
+
                     $scope.$on('$stateChangeStart', function (event, next, current) {
                         var uuid = $state.params.patientUuid;
                         var currentUuid = current.patientUuid;
                         var isNavigating = exitAlertService.setIsNavigating(next, uuid, currentUuid);
-                        $state.dirtyConsultationForm = $state.discardChanges ? false : $state.dirtyConsultationForm;
+
+                        if ($state.justSaved) {
+                            $state.dirtyConsultationForm = false;
+                            if (isNavigating && uuid !== currentUuid) {
+                                $state.justSaved = false;
+                            }
+                        } else {
+                            $state.dirtyConsultationForm = $state.discardChanges ? false : $state.dirtyConsultationForm;
+                        }
                         exitAlertService.showExitAlert(isNavigating, $state.dirtyConsultationForm, event, next.spinnerToken);
                     });
                 }

--- a/ui/test/unit/clinical/consultation/directives/alertOnExit.spec.js
+++ b/ui/test/unit/clinical/consultation/directives/alertOnExit.spec.js
@@ -71,4 +71,99 @@ describe('alertOnExit Directive', function () {
 
         expect($state.justSaved).toBe(false);
     });
+
+    describe('Popup After Main Save Scenario', function () {
+        var element;
+
+        beforeEach(function () {
+            element = angular.element('<div alert-on-exit></div>');
+            $compile(element)($scope);
+            $scope.$digest();
+        });
+
+        it('should not show popup when navigating after successful main save with no new changes', function () {
+            exitAlertService.setIsNavigating.and.returnValue(false);
+            $state.justSaved = true;
+            $state.dirtyConsultationForm = true;
+
+            var next = { url: '/other/page', spinnerToken: 'spinner' };
+            var current = { patientUuid: 'currentPatientUuid' };
+            var event = $rootScope.$broadcast('$stateChangeStart', next, current);
+
+            expect($state.dirtyConsultationForm).toBe(false);
+            expect(exitAlertService.showExitAlert).toHaveBeenCalledWith(false, false, event, 'spinner');
+        });
+
+        it('should suppress popup when form refreshes during post-save window', function () {
+            $state.justSaved = true;
+            $state.dirtyConsultationForm = true;
+            var next = { url: '/patient/search', spinnerToken: 'spinner' };
+            var current = { patientUuid: 'currentPatientUuid' };
+
+            var event = $rootScope.$broadcast('$stateChangeStart', next, current);
+
+            expect($state.dirtyConsultationForm).toBe(false);
+            expect(exitAlertService.showExitAlert).toHaveBeenCalledWith(true, false, event, 'spinner');
+        });
+
+        it('should show popup when user makes new edits after save', function () {
+            exitAlertService.setIsNavigating.and.returnValue(true);
+            $state.justSaved = false; // justSaved was reset when new edits detected
+            $state.dirtyConsultationForm = true;
+
+            var next = { url: '/patient/search', spinnerToken: 'spinner' };
+            var current = { patientUuid: 'currentPatientUuid' };
+            var event = $rootScope.$broadcast('$stateChangeStart', next, current);
+
+            expect($state.dirtyConsultationForm).toBe(true);
+            expect(exitAlertService.showExitAlert).toHaveBeenCalledWith(true, true, event, 'spinner');
+        });
+
+        it('should clear justSaved flag when navigating between patients after save', function () {
+            $state.justSaved = true;
+            $state.dirtyConsultationForm = true;
+            $state.params.patientUuid = 'patientA';
+
+            var next = { url: '/patient/patientB/page', spinnerToken: 'spinner' };
+            var current = { patientUuid: 'patientB' }; // Different patient
+
+            var event = $rootScope.$broadcast('$stateChangeStart', next, current);
+
+            expect($state.justSaved).toBe(false);
+            expect($state.dirtyConsultationForm).toBe(false);
+        });
+
+        it('should keep justSaved true when navigating within same patient after save', function () {
+            $state.justSaved = true;
+            $state.dirtyConsultationForm = true;
+            $state.params.patientUuid = 'samePatient';
+
+            var next = { url: '/patient/samePatient/observations', spinnerToken: 'spinner' };
+            var current = { patientUuid: 'samePatient' };
+
+            var event = $rootScope.$broadcast('$stateChangeStart', next, current);
+
+            expect($state.justSaved).toBe(true); // Still true for same patient navigation
+            expect($state.dirtyConsultationForm).toBe(false);
+        });
+
+        it('should handle rapid navigation events after save correctly', function () {
+            $state.justSaved = true;
+            $state.dirtyConsultationForm = true;
+
+            var next1 = { url: '/patient/search', spinnerToken: 'spinner1' };
+            var current1 = { patientUuid: 'currentPatientUuid' };
+            var event1 = $rootScope.$broadcast('$stateChangeStart', next1, current1);
+
+            expect($state.dirtyConsultationForm).toBe(false);
+
+            $state.dirtyConsultationForm = true; // Reset for next test
+            var next2 = { url: '/admin/page', spinnerToken: 'spinner2' };
+            var current2 = { patientUuid: 'differentPatient' };
+            var event2 = $rootScope.$broadcast('$stateChangeStart', next2, current2);
+
+            expect($state.justSaved).toBe(false);
+            expect($state.dirtyConsultationForm).toBe(false);
+        });
+    });
 });

--- a/ui/test/unit/clinical/consultation/directives/alertOnExit.spec.js
+++ b/ui/test/unit/clinical/consultation/directives/alertOnExit.spec.js
@@ -38,4 +38,37 @@ describe('alertOnExit Directive', function () {
         expect(exitAlertService.setIsNavigating).toHaveBeenCalledWith(next, 'currentPatientUuid', 'previousPatientUuid');
         expect(exitAlertService.showExitAlert).toHaveBeenCalledWith(true, true, event, 'spinner');
     });
+
+    it('should not show popup after main save when navigating away', function () {
+        exitAlertService.setIsNavigating.and.returnValue(false);
+        var element = angular.element('<div alert-on-exit></div>');
+        $compile(element)($scope);
+        $scope.$digest();
+
+        $state.justSaved = true;
+        $state.dirtyConsultationForm = true;
+
+        var next = { url: '/other/page', spinnerToken: 'spinner' };
+        var current = { patientUuid: 'currentPatientUuid' };
+        var event = $rootScope.$broadcast('$stateChangeStart', next, current);
+
+        expect($state.dirtyConsultationForm).toBe(false);
+    });
+
+    it('should reset justSaved flag when navigating to a different patient after save', function () {
+        var element = angular.element('<div alert-on-exit></div>');
+        $compile(element)($scope);
+        $scope.$digest();
+
+        $state.justSaved = true;
+        $state.dirtyConsultationForm = true;
+
+        var next = { url: '/patient/123/page', spinnerToken: 'spinner' };
+        var current = { patientUuid: 'differentPatientUuid' };
+        $state.params.patientUuid = 'currentPatientUuid';
+
+        var event = $rootScope.$broadcast('$stateChangeStart', next, current);
+
+        expect($state.justSaved).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary
Prevent unsaved data popup from appearing after main consultation save.

## Why
Users were seeing a confusing "unsaved data" popup after successfully saving and navigating away. This broke the expected UX flow and undermined confidence in the save functionality.

## Root Cause
The form dirty-state watcher was triggering on post-save server updates (timestamps, IDs) and incorrectly marking the form as dirty, overriding the `justSaved` flag that was meant to suppress the popup.

## Solution
Added state guards (`mainSaveInProgress` and `justSaved` flag checks) to the form watcher so it ignores updates during/after save but continues detecting actual user edits.

**Why this approach:**
- Preserves continuous dirty tracking (vs disabling the watcher after save)
- Auto-resets the save flag if user makes new edits
- Prevents false positives without losing legitimate dirty detection

## Testing
✓ No popup after save + navigation
✓ Popup appears for new user edits
✓ Auto-save works correctly
✓ Extra observations tracked

## Files
- alertOnExit.js - Set `justSaved` on successful save
- conceptSetPageController.js - Guard watcher with save state flags
- consultationController.js - Set `mainSaveInProgress` during save
- formControls.js - Post-save cleanup
- alertOnExit.spec.js - Tests for popup suppression

Hive card: https://app.hive.com/workspace/adoBEQk5LKDDYFd8b?actionId=oTeo6HYLmg6fQjWZk
